### PR TITLE
Added support for Scintilla 3.6 and newer versions.

### DIFF
--- a/Sources/DScintillaCustom.pas
+++ b/Sources/DScintillaCustom.pas
@@ -107,7 +107,7 @@ type
     /// <summary>Sends message to Scintilla control.
     /// For list of commands see DScintillaTypes.pas and documentation at:
     /// http://www.scintilla.org/ScintillaDoc.html</summary>
-    function SendEditor(AMessage: Integer; WParam: NativeInt = 0; LParam: NativeInt = 0): NativeInt; virtual;
+    function SendEditor(AMessage: UINT; WParam: WPARAM = 0; LParam: LPARAM = 0): LRESULT; virtual;
 
   published
 
@@ -434,7 +434,7 @@ begin
   end;
 end;
 
-function TDScintillaCustom.SendEditor(AMessage: Integer; WParam: NativeInt; LParam: NativeInt): NativeInt;
+function TDScintillaCustom.SendEditor(AMessage: UINT; WParam: WPARAM; LParam: LPARAM): LRESULT;
 begin
   HandleNeeded;
 

--- a/Sources/DScintillaMethodsCode.inc
+++ b/Sources/DScintillaMethodsCode.inc
@@ -8,7 +8,7 @@ begin
   SendEditor(SCI_ADDSTYLEDTEXT, System.Length(ACells) * 2, Integer(ACells));
 end;
 
-procedure TDScintilla.InsertText(APos: Integer; const AText: UnicodeString);
+procedure TDScintilla.InsertText(APos: NativeInt; const AText: UnicodeString);
 begin
   FHelper.SetText(SCI_INSERTTEXT, APos, AText);
 end;
@@ -23,7 +23,7 @@ begin
   SendEditor(SCI_CLEARALL, 0, 0);
 end;
 
-procedure TDScintilla.DeleteRange(APos: Integer; ADeleteLength: Integer);
+procedure TDScintilla.DeleteRange(APos: NativeInt; ADeleteLength: NativeInt);
 begin
   SendEditor(SCI_DELETERANGE, APos, ADeleteLength);
 end;
@@ -48,7 +48,7 @@ begin
   SendEditor(SCI_SETSAVEPOINT, 0, 0);
 end;
 
-function TDScintilla.GetStyledText(AStart, AEnd: Integer): TDSciCells;
+function TDScintilla.GetStyledText(AStart, AEnd: Long): TDSciCells;
 var
   lRange: TDSciTextRange;
 begin
@@ -72,7 +72,7 @@ begin
   Result := Boolean(SendEditor(SCI_CANREDO, 0, 0));
 end;
 
-function TDScintilla.MarkerLineFromHandle(AHandle: Integer): Integer;
+function TDScintilla.MarkerLineFromHandle(AHandle: Integer): NativeInt;
 begin
   Result := SendEditor(SCI_MARKERLINEFROMHANDLE, AHandle, 0);
 end;
@@ -82,27 +82,27 @@ begin
   SendEditor(SCI_MARKERDELETEHANDLE, AHandle, 0);
 end;
 
-function TDScintilla.PositionFromPoint(AX: Integer; AY: Integer): Integer;
+function TDScintilla.PositionFromPoint(AX: Integer; AY: Integer): NativeInt;
 begin
   Result := SendEditor(SCI_POSITIONFROMPOINT, AX, AY);
 end;
 
-function TDScintilla.PositionFromPointClose(AX: Integer; AY: Integer): Integer;
+function TDScintilla.PositionFromPointClose(AX: Integer; AY: Integer): NativeInt;
 begin
   Result := SendEditor(SCI_POSITIONFROMPOINTCLOSE, AX, AY);
 end;
 
-procedure TDScintilla.GotoLine(ALine: Integer);
+procedure TDScintilla.GotoLine(ALine: NativeInt);
 begin
   SendEditor(SCI_GOTOLINE, ALine, 0);
 end;
 
-procedure TDScintilla.GotoPos(APos: Integer);
+procedure TDScintilla.GotoPos(APos: NativeInt);
 begin
   SendEditor(SCI_GOTOPOS, APos, 0);
 end;
 
-function TDScintilla.GetCurLine(var AText: UnicodeString): Integer;
+function TDScintilla.GetCurLine(var AText: UnicodeString): NativeInt;
 begin
   Result := FHelper.GetTextLen(SCI_GETCURLINE, AText);
 end;
@@ -112,12 +112,12 @@ begin
   SendEditor(SCI_CONVERTEOLS, AEolMode, 0);
 end;
 
-procedure TDScintilla.StartStyling(APos: Integer; AMask: Integer);
+procedure TDScintilla.StartStyling(APos: NativeInt; AMask: Integer);
 begin
   SendEditor(SCI_STARTSTYLING, APos, AMask);
 end;
 
-procedure TDScintilla.SetStyling(ALength: Integer; AStyle: Integer);
+procedure TDScintilla.SetStyling(ALength: NativeInt; AStyle: Integer);
 begin
   SendEditor(SCI_SETSTYLING, ALength, AStyle);
 end;
@@ -147,12 +147,12 @@ begin
   SendEditor(SCI_MARKERENABLEHIGHLIGHT, Integer(AEnabled), 0);
 end;
 
-function TDScintilla.MarkerAdd(ALine: Integer; AMarkerNumber: Integer): Integer;
+function TDScintilla.MarkerAdd(ALine: NativeInt; AMarkerNumber: Integer): Integer;
 begin
   Result := SendEditor(SCI_MARKERADD, ALine, AMarkerNumber);
 end;
 
-procedure TDScintilla.MarkerDelete(ALine: Integer; AMarkerNumber: Integer);
+procedure TDScintilla.MarkerDelete(ALine: NativeInt; AMarkerNumber: Integer);
 begin
   SendEditor(SCI_MARKERDELETE, ALine, AMarkerNumber);
 end;
@@ -162,17 +162,17 @@ begin
   SendEditor(SCI_MARKERDELETEALL, AMarkerNumber, 0);
 end;
 
-function TDScintilla.MarkerGet(ALine: Integer): Integer;
+function TDScintilla.MarkerGet(ALine: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_MARKERGET, ALine, 0);
 end;
 
-function TDScintilla.MarkerNext(ALineStart: Integer; AMarkerMask: Integer): Integer;
+function TDScintilla.MarkerNext(ALineStart: NativeInt; AMarkerMask: Integer): NativeInt;
 begin
   Result := SendEditor(SCI_MARKERNEXT, ALineStart, AMarkerMask);
 end;
 
-function TDScintilla.MarkerPrevious(ALineStart: Integer; AMarkerMask: Integer): Integer;
+function TDScintilla.MarkerPrevious(ALineStart: NativeInt; AMarkerMask: Integer): NativeInt;
 begin
   Result := SendEditor(SCI_MARKERPREVIOUS, ALineStart, AMarkerMask);
 end;
@@ -182,7 +182,7 @@ begin
   SendEditor(SCI_MARKERDEFINEPIXMAP, AMarkerNumber, NativeInt(APixmap));
 end;
 
-procedure TDScintilla.MarkerAddSet(ALine: Integer; ASet: Integer);
+procedure TDScintilla.MarkerAddSet(ALine: NativeInt; ASet: Integer);
 begin
   SendEditor(SCI_MARKERADDSET, ALine, ASet);
 end;
@@ -257,7 +257,7 @@ begin
   SendEditor(SCI_SETWHITESPACEBACK, Integer(AUseSetting), Integer(ABack));
 end;
 
-procedure TDScintilla.AutoCShow(ALenEntered: Integer; const AItemList: UnicodeString);
+procedure TDScintilla.AutoCShow(ALenEntered: NativeInt; const AItemList: UnicodeString);
 begin
   FHelper.SetText(SCI_AUTOCSHOW, ALenEntered, AItemList);
 end;
@@ -272,7 +272,7 @@ begin
   Result := Boolean(SendEditor(SCI_AUTOCACTIVE, 0, 0));
 end;
 
-function TDScintilla.AutoCPosStart: Integer;
+function TDScintilla.AutoCPosStart: NativeInt;
 begin
   Result := SendEditor(SCI_AUTOCPOSSTART, 0, 0);
 end;
@@ -308,17 +308,17 @@ begin
   SendEditor(SCI_CLEARREGISTEREDIMAGES, 0, 0);
 end;
 
-function TDScintilla.CountCharacters(AStartPos: Integer; AEndPos: Integer): Integer;
+function TDScintilla.CountCharacters(AStartPos: NativeInt; AEndPos: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_COUNTCHARACTERS, AStartPos, AEndPos);
 end;
 
-procedure TDScintilla.SetEmptySelection(APos: Integer);
+procedure TDScintilla.SetEmptySelection(APos: NativeInt);
 begin
   SendEditor(SCI_SETEMPTYSELECTION, APos, 0);
 end;
 
-function TDScintilla.FindText(AFlags: Integer; const AText: UnicodeString; var ARange: TDSciCharacterRange): Integer;
+function TDScintilla.FindText(AFlags: Integer; const AText: UnicodeString; var ARange: TDSciCharacterRange): NativeInt;
 var
   lRange: TDSciTextToFind;
 begin
@@ -337,17 +337,17 @@ begin
     ARange := lRange.chrgText;
 end;
 
-function TDScintilla.FormatRange(ADraw: Boolean; var AFr: TDSciRangeToFormat): Integer;
+function TDScintilla.FormatRange(ADraw: Boolean; var AFr: TDSciRangeToFormat): NativeInt;
 begin
   Result := SendEditor(SCI_FORMATRANGE, Integer(ADraw), Integer(@AFr));
 end;
 
-function TDScintilla.GetLine(ALine: Integer): UnicodeString;
+function TDScintilla.GetLine(ALine: NativeInt): UnicodeString;
 begin
   FHelper.GetText(SCI_GETLINE, ALine, Result);
 end;
 
-procedure TDScintilla.SetSel(AStart: Integer; AEnd: Integer);
+procedure TDScintilla.SetSel(AStart: NativeInt; AEnd: NativeInt);
 begin
   SendEditor(SCI_SETSEL, AStart, AEnd);
 end;
@@ -357,11 +357,11 @@ begin
   FHelper.GetText(SCI_GETSELTEXT, 0, Result);
 end;
 
-function TDScintilla.GetTextRange(AStart, AEnd: Integer): UnicodeString;
+function TDScintilla.GetTextRange(AStart, AEnd: NativeInt): UnicodeString;
 var
   lRange: TDSciTextRange;
   lChars: TDSciChars;
-  lActualLength: Integer;
+  lActualLength: NativeInt;
 begin
   Result := '';
 
@@ -391,27 +391,27 @@ begin
   SendEditor(SCI_HIDESELECTION, Integer(ANormal), 0);
 end;
 
-function TDScintilla.PointXFromPosition(APos: Integer): Integer;
+function TDScintilla.PointXFromPosition(APos: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_POINTXFROMPOSITION, 0, APos);
 end;
 
-function TDScintilla.PointYFromPosition(APos: Integer): Integer;
+function TDScintilla.PointYFromPosition(APos: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_POINTYFROMPOSITION, 0, APos);
 end;
 
-function TDScintilla.LineFromPosition(APos: Integer): Integer;
+function TDScintilla.LineFromPosition(APos: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_LINEFROMPOSITION, APos, 0);
 end;
 
-function TDScintilla.PositionFromLine(ALine: Integer): Integer;
+function TDScintilla.PositionFromLine(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_POSITIONFROMLINE, ALine, 0);
 end;
 
-procedure TDScintilla.LineScroll(AColumns: Integer; ALines: Integer);
+procedure TDScintilla.LineScroll(AColumns: NativeInt; ALines: NativeInt);
 begin
   SendEditor(SCI_LINESCROLL, AColumns, ALines);
 end;
@@ -421,7 +421,7 @@ begin
   SendEditor(SCI_SCROLLCARET, 0, 0);
 end;
 
-procedure TDScintilla.ScrollRange(ASecondary: Integer; APrimary: Integer);
+procedure TDScintilla.ScrollRange(ASecondary: NativeInt; APrimary: NativeInt);
 begin
   SendEditor(SCI_SCROLLRANGE, ASecondary, APrimary);
 end;
@@ -486,22 +486,22 @@ begin
   FHelper.GetTextLen(SCI_GETTEXT, Result);
 end;
 
-function TDScintilla.ReplaceTarget(const AText: UnicodeString): Integer;
+function TDScintilla.ReplaceTarget(const AText: UnicodeString): NativeInt;
 begin
   Result := FHelper.SetTextLen(SCI_REPLACETARGET, AText);
 end;
 
-function TDScintilla.ReplaceTargetRE(const AText: UnicodeString): Integer;
+function TDScintilla.ReplaceTargetRE(const AText: UnicodeString): NativeInt;
 begin
   Result := FHelper.SetTextLen(SCI_REPLACETARGETRE, AText);
 end;
 
-function TDScintilla.SearchInTarget(const AText: UnicodeString): Integer;
+function TDScintilla.SearchInTarget(const AText: UnicodeString): NativeInt;
 begin
   Result := FHelper.SetTextLen(SCI_SEARCHINTARGET, AText);
 end;
 
-procedure TDScintilla.CallTipShow(APos: Integer; const ADefinition: UnicodeString);
+procedure TDScintilla.CallTipShow(APos: NativeInt; const ADefinition: UnicodeString);
 begin
   if ADefinition = '' then
     CallTipCancel
@@ -519,7 +519,7 @@ begin
   Result := Boolean(SendEditor(SCI_CALLTIPACTIVE, 0, 0));
 end;
 
-function TDScintilla.CallTipPosStart: Integer;
+function TDScintilla.CallTipPosStart: NativeInt;
 begin
   Result := SendEditor(SCI_CALLTIPPOSSTART, 0, 0);
 end;
@@ -529,47 +529,47 @@ begin
   SendEditor(SCI_CALLTIPSETHLT, AStart, AEnd);
 end;
 
-function TDScintilla.VisibleFromDocLine(ALine: Integer): Integer;
+function TDScintilla.VisibleFromDocLine(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_VISIBLEFROMDOCLINE, ALine, 0);
 end;
 
-function TDScintilla.DocLineFromVisible(ALineDisplay: Integer): Integer;
+function TDScintilla.DocLineFromVisible(ALineDisplay: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_DOCLINEFROMVISIBLE, ALineDisplay, 0);
 end;
 
-function TDScintilla.WrapCount(ALine: Integer): Integer;
+function TDScintilla.WrapCount(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_WRAPCOUNT, ALine, 0);
 end;
 
-procedure TDScintilla.ShowLines(ALineStart: Integer; ALineEnd: Integer);
+procedure TDScintilla.ShowLines(ALineStart: NativeInt; ALineEnd: NativeInt);
 begin
   SendEditor(SCI_SHOWLINES, ALineStart, ALineEnd);
 end;
 
-procedure TDScintilla.HideLines(ALineStart: Integer; ALineEnd: Integer);
+procedure TDScintilla.HideLines(ALineStart: NativeInt; ALineEnd: NativeInt);
 begin
   SendEditor(SCI_HIDELINES, ALineStart, ALineEnd);
 end;
 
-procedure TDScintilla.ToggleFold(ALine: Integer);
+procedure TDScintilla.ToggleFold(ALine: NativeInt);
 begin
   SendEditor(SCI_TOGGLEFOLD, ALine, 0);
 end;
 
-procedure TDScintilla.FoldLine(ALine: Integer; AAction: Integer);
+procedure TDScintilla.FoldLine(ALine: NativeInt; AAction: Integer);
 begin
   SendEditor(SCI_FOLDLINE, ALine, AAction);
 end;
 
-procedure TDScintilla.FoldChildren(ALine: Integer; AAction: Integer);
+procedure TDScintilla.FoldChildren(ALine: NativeInt; AAction: Integer);
 begin
   SendEditor(SCI_FOLDCHILDREN, ALine, AAction);
 end;
 
-procedure TDScintilla.ExpandChildren(ALine: Integer; ALevel: Integer);
+procedure TDScintilla.ExpandChildren(ALine: NativeInt; ALevel: Integer);
 begin
   SendEditor(SCI_EXPANDCHILDREN, ALine, ALevel);
 end;
@@ -579,7 +579,7 @@ begin
   SendEditor(SCI_FOLDALL, AAction, 0);
 end;
 
-procedure TDScintilla.EnsureVisible(ALine: Integer);
+procedure TDScintilla.EnsureVisible(ALine: NativeInt);
 begin
   SendEditor(SCI_ENSUREVISIBLE, ALine, 0);
 end;
@@ -589,17 +589,17 @@ begin
   SendEditor(SCI_SETFOLDFLAGS, AFlags, 0);
 end;
 
-procedure TDScintilla.EnsureVisibleEnforcePolicy(ALine: Integer);
+procedure TDScintilla.EnsureVisibleEnforcePolicy(ALine: NativeInt);
 begin
   SendEditor(SCI_ENSUREVISIBLEENFORCEPOLICY, ALine, 0);
 end;
 
-function TDScintilla.WordStartPosition(APos: Integer; AOnlyWordCharacters: Boolean): Integer;
+function TDScintilla.WordStartPosition(APos: NativeInt; AOnlyWordCharacters: Boolean): NativeInt;
 begin
   Result := SendEditor(SCI_WORDSTARTPOSITION, APos, Integer(AOnlyWordCharacters));
 end;
 
-function TDScintilla.WordEndPosition(APos: Integer; AOnlyWordCharacters: Boolean): Integer;
+function TDScintilla.WordEndPosition(APos: NativeInt; AOnlyWordCharacters: Boolean): NativeInt;
 begin
   Result := SendEditor(SCI_WORDENDPOSITION, APos, Integer(AOnlyWordCharacters));
 end;
@@ -609,7 +609,7 @@ begin
   Result := FHelper.SetText(SCI_TEXTWIDTH, AStyle, AText);
 end;
 
-function TDScintilla.TextHeight(ALine: Integer): Integer;
+function TDScintilla.TextHeight(ALine: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_TEXTHEIGHT, ALine, 0);
 end;
@@ -944,12 +944,12 @@ begin
   SendEditor(SCI_MOVECARETINSIDEVIEW, 0, 0);
 end;
 
-function TDScintilla.LineLength(ALine: Integer): Integer;
+function TDScintilla.LineLength(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_LINELENGTH, ALine, 0);
 end;
 
-procedure TDScintilla.BraceHighlight(APos1: Integer; APos2: Integer);
+procedure TDScintilla.BraceHighlight(APos1: NativeInt; APos2: NativeInt);
 begin
   SendEditor(SCI_BRACEHIGHLIGHT, APos1, APos2);
 end;
@@ -959,7 +959,7 @@ begin
   SendEditor(SCI_BRACEHIGHLIGHTINDICATOR, Integer(AUseBraceHighlightIndicator), AIndicator);
 end;
 
-procedure TDScintilla.BraceBadLight(APos: Integer);
+procedure TDScintilla.BraceBadLight(APos: NativeInt);
 begin
   SendEditor(SCI_BRACEBADLIGHT, APos, 0);
 end;
@@ -969,7 +969,7 @@ begin
   SendEditor(SCI_BRACEBADLIGHTINDICATOR, Integer(AUseBraceBadLightIndicator), AIndicator);
 end;
 
-function TDScintilla.BraceMatch(APos: Integer): Integer;
+function TDScintilla.BraceMatch(APos: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_BRACEMATCH, APos, 0);
 end;
@@ -979,17 +979,17 @@ begin
   SendEditor(SCI_SEARCHANCHOR, 0, 0);
 end;
 
-function TDScintilla.SearchNext(AFlags: Integer; const AText: UnicodeString): Integer;
+function TDScintilla.SearchNext(AFlags: Integer; const AText: UnicodeString): NativeInt;
 begin
   Result := FHelper.SetText(SCI_SEARCHNEXT, AFlags, AText);
 end;
 
-function TDScintilla.SearchPrev(AFlags: Integer; const AText: UnicodeString): Integer;
+function TDScintilla.SearchPrev(AFlags: Integer; const AText: UnicodeString): NativeInt;
 begin
   Result := FHelper.SetText(SCI_SEARCHPREV, AFlags, AText);
 end;
 
-function TDScintilla.LinesOnScreen: Integer;
+function TDScintilla.LinesOnScreen: NativeInt;
 begin
   Result := SendEditor(SCI_LINESONSCREEN, 0, 0);
 end;
@@ -1096,22 +1096,22 @@ begin
   SendEditor(SCI_PARAUPEXTEND, 0, 0);
 end;
 
-function TDScintilla.PositionBefore(APos: Integer): Integer;
+function TDScintilla.PositionBefore(APos: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_POSITIONBEFORE, APos, 0);
 end;
 
-function TDScintilla.PositionAfter(APos: Integer): Integer;
+function TDScintilla.PositionAfter(APos: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_POSITIONAFTER, APos, 0);
 end;
 
-function TDScintilla.PositionRelative(APos: Integer; ARelative: Integer): Integer;
+function TDScintilla.PositionRelative(APos: NativeInt; ARelative: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_POSITIONRELATIVE, APos, ARelative);
 end;
 
-procedure TDScintilla.CopyRange(AStart: Integer; AEnd: Integer);
+procedure TDScintilla.CopyRange(AStart: NativeInt; AEnd: NativeInt);
 begin
   SendEditor(SCI_COPYRANGE, AStart, AEnd);
 end;
@@ -1120,12 +1120,12 @@ procedure TDScintilla.CopyText(const AText: UnicodeString);
 begin
   FHelper.SetTextLen(SCI_COPYTEXT, AText);
 end;
-function TDScintilla.GetLineSelStartPosition(ALine: Integer): Integer;
+function TDScintilla.GetLineSelStartPosition(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_GETLINESELSTARTPOSITION, ALine, 0);
 end;
 
-function TDScintilla.GetLineSelEndPosition(ALine: Integer): Integer;
+function TDScintilla.GetLineSelEndPosition(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_GETLINESELENDPOSITION, ALine, 0);
 end;
@@ -1230,7 +1230,7 @@ begin
   FHelper.GetText(SCI_AUTOCGETCURRENTTEXT, 0, Result);
 end;
 
-procedure TDScintilla.Allocate(ABytes: Integer);
+procedure TDScintilla.Allocate(ABytes: NativeInt);
 begin
   SendEditor(SCI_ALLOCATE, ABytes, 0);
 end;
@@ -1250,7 +1250,7 @@ end;
 //   Result := SendEditor(SCI_ENCODEDFROMUTF8, Integer(AUtf8), Integer(AEncoded));
 // end;
 
-function TDScintilla.FindColumn(ALine: Integer; AColumn: Integer): Integer;
+function TDScintilla.FindColumn(ALine: NativeInt; AColumn: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_FINDCOLUMN, ALine, AColumn);
 end;
@@ -1265,32 +1265,32 @@ begin
   SendEditor(SCI_SELECTIONDUPLICATE, 0, 0);
 end;
 
-procedure TDScintilla.IndicatorFillRange(APosition: Integer; AFillLength: Integer);
+procedure TDScintilla.IndicatorFillRange(APosition: NativeInt; AFillLength: NativeInt);
 begin
   SendEditor(SCI_INDICATORFILLRANGE, APosition, AFillLength);
 end;
 
-procedure TDScintilla.IndicatorClearRange(APosition: Integer; AClearLength: Integer);
+procedure TDScintilla.IndicatorClearRange(APosition: NativeInt; AClearLength: NativeInt);
 begin
   SendEditor(SCI_INDICATORCLEARRANGE, APosition, AClearLength);
 end;
 
-function TDScintilla.IndicatorAllOnFor(APosition: Integer): Integer;
+function TDScintilla.IndicatorAllOnFor(APosition: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_INDICATORALLONFOR, APosition, 0);
 end;
 
-function TDScintilla.IndicatorValueAt(AIndicator: Integer; APosition: Integer): Integer;
+function TDScintilla.IndicatorValueAt(AIndicator: Integer; APosition: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_INDICATORVALUEAT, AIndicator, APosition);
 end;
 
-function TDScintilla.IndicatorStart(AIndicator: Integer; APosition: Integer): Integer;
+function TDScintilla.IndicatorStart(AIndicator: Integer; APosition: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_INDICATORSTART, AIndicator, APosition);
 end;
 
-function TDScintilla.IndicatorEnd(AIndicator: Integer; APosition: Integer): Integer;
+function TDScintilla.IndicatorEnd(AIndicator: Integer; APosition: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_INDICATOREND, AIndicator, APosition);
 end;
@@ -1300,7 +1300,7 @@ begin
   SendEditor(SCI_COPYALLOWLINE, 0, 0);
 end;
 
-function TDScintilla.GetGapPosition: Integer;
+function TDScintilla.GetGapPosition: NativeInt;
 begin
   Result := SendEditor(SCI_GETGAPPOSITION, 0, 0);
 end;
@@ -1335,12 +1335,12 @@ begin
   SendEditor(SCI_ADDUNDOACTION, AToken, AFlags);
 end;
 
-function TDScintilla.CharPositionFromPoint(AX: Integer; AY: Integer): Integer;
+function TDScintilla.CharPositionFromPoint(AX: Integer; AY: Integer): NativeInt;
 begin
   Result := SendEditor(SCI_CHARPOSITIONFROMPOINT, AX, AY);
 end;
 
-function TDScintilla.CharPositionFromPointClose(AX: Integer; AY: Integer): Integer;
+function TDScintilla.CharPositionFromPointClose(AX: Integer; AY: Integer): NativeInt;
 begin
   Result := SendEditor(SCI_CHARPOSITIONFROMPOINTCLOSE, AX, AY);
 end;
@@ -1350,17 +1350,17 @@ begin
   SendEditor(SCI_CLEARSELECTIONS, 0, 0);
 end;
 
-function TDScintilla.SetSelection(ACaret: Integer; AAnchor: Integer): Integer;
+function TDScintilla.SetSelection(ACaret: NativeInt; AAnchor: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_SETSELECTION, ACaret, AAnchor);
 end;
 
-function TDScintilla.AddSelection(ACaret: Integer; AAnchor: Integer): Integer;
+function TDScintilla.AddSelection(ACaret: NativeInt; AAnchor: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_ADDSELECTION, ACaret, AAnchor);
 end;
 
-procedure TDScintilla.DropSelectionN(ASelection: Integer);
+procedure TDScintilla.DropSelectionN(ASelection: NativeInt);
 begin
   SendEditor(SCI_DROPSELECTIONN, ASelection, 0);
 end;
@@ -1375,12 +1375,12 @@ begin
   SendEditor(SCI_SWAPMAINANCHORCARET, 0, 0);
 end;
 
-function TDScintilla.ChangeLexerState(AStart: Integer; AEnd: Integer): Integer;
+function TDScintilla.ChangeLexerState(AStart: NativeInt; AEnd: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_CHANGELEXERSTATE, AStart, AEnd);
 end;
 
-function TDScintilla.ContractedFoldNext(ALineStart: Integer): Integer;
+function TDScintilla.ContractedFoldNext(ALineStart: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_CONTRACTEDFOLDNEXT, ALineStart, 0);
 end;
@@ -1425,7 +1425,7 @@ begin
   SendEditor(SCI_SCROLLTOEND, 0, 0);
 end;
 
-function TDScintilla.CreateLoader(ABytes: Integer): Pointer;
+function TDScintilla.CreateLoader(ABytes: NativeInt): Pointer;
 begin
   Result := Pointer(SendEditor(SCI_CREATELOADER, ABytes, 0));
 end;
@@ -1470,7 +1470,7 @@ begin
   SendEditor(SCI_STOPRECORD, 0, 0);
 end;
 
-procedure TDScintilla.Colourise(AStart: Integer; AEnd: Integer);
+procedure TDScintilla.Colourise(AStart: NativeInt; AEnd: NativeInt);
 begin
   SendEditor(SCI_COLOURISE, AStart, AEnd);
 end;
@@ -1506,9 +1506,9 @@ begin
     FHelper.GetText(SCI_GETPROPERTYEXPANDED, NativeInt(AnsiString(AKey)), Result);
 end;
 
-function TDScintilla.PrivateLexerCall(AOperation: Integer; APointer: Integer): Integer;
+function TDScintilla.PrivateLexerCall(AOperation: Integer; APointer: Pointer): NativeInt;
 begin
-  Result := SendEditor(SCI_PRIVATELEXERCALL, AOperation, APointer);
+  Result := SendEditor(SCI_PRIVATELEXERCALL, AOperation, LPARAM(APointer));
 end;
 
 function TDScintilla.PropertyNames: UnicodeString;

--- a/Sources/DScintillaMethodsDecl.inc
+++ b/Sources/DScintillaMethodsDecl.inc
@@ -5,7 +5,7 @@
     procedure AddStyledText(const ACells: TDSciCells);
 
     /// <summary>Insert string at a position.</summary>
-    procedure InsertText(APos: Integer; const AText: UnicodeString);
+    procedure InsertText(APos: NativeInt; const AText: UnicodeString);
 
     /// <summary>Change the text that is being inserted in response to SC_MOD_INSERTCHECK</summary>
     procedure ChangeInsertion(const AText: UnicodeString);
@@ -14,7 +14,7 @@
     procedure ClearAll;
 
     /// <summary>Delete a range of text in the document.</summary>
-    procedure DeleteRange(APos: Integer; ADeleteLength: Integer);
+    procedure DeleteRange(APos: NativeInt; ADeleteLength: NativeInt);
 
     /// <summary>Set all style bytes to 0, remove all folding information.</summary>
     procedure ClearDocumentStyle;
@@ -31,44 +31,44 @@
 
     /// <summary>Retrieve a buffer of cells.
     /// Returns the number of bytes in the buffer not including terminating NULs.</summary>
-    function GetStyledText(AStart, AEnd: Integer): TDSciCells;
+    function GetStyledText(AStart, AEnd: Long): TDSciCells;
 
     /// <summary>Are there any redoable actions in the undo history?</summary>
     function CanRedo: Boolean;
 
     /// <summary>Retrieve the line number at which a particular marker is located.</summary>
-    function MarkerLineFromHandle(AHandle: Integer): Integer;
+    function MarkerLineFromHandle(AHandle: Integer): NativeInt;
 
     /// <summary>Delete a marker.</summary>
     procedure MarkerDeleteHandle(AHandle: Integer);
 
     /// <summary>Find the position from a point within the window.</summary>
-    function PositionFromPoint(AX: Integer; AY: Integer): Integer;
+    function PositionFromPoint(AX: Integer; AY: Integer): NativeInt;
 
     /// <summary>Find the position from a point within the window but return
     /// INVALID_POSITION if not close to text.</summary>
-    function PositionFromPointClose(AX: Integer; AY: Integer): Integer;
+    function PositionFromPointClose(AX: Integer; AY: Integer): NativeInt;
 
     /// <summary>Set caret to start of a line and ensure it is visible.</summary>
-    procedure GotoLine(ALine: Integer);
+    procedure GotoLine(ALine: NativeInt);
 
     /// <summary>Set caret to a position and ensure it is visible.</summary>
-    procedure GotoPos(APos: Integer);
+    procedure GotoPos(APos: NativeInt);
 
     /// <summary>Retrieve the text of the line containing the caret.
     /// Returns the index of the caret on the line.</summary>
-    function GetCurLine(var AText: UnicodeString): Integer;
+    function GetCurLine(var AText: UnicodeString): NativeInt;
 
     /// <summary>Convert all line endings in the document to one mode.</summary>
     procedure ConvertEOLs(AEolMode: Integer);
 
     /// <summary>Set the current styling position to pos and the styling mask to mask.
     /// The styling mask can be used to protect some bits in each styling byte from modification.</summary>
-    procedure StartStyling(APos: Integer; AMask: Integer);
+    procedure StartStyling(APos: NativeInt; AMask: Integer);
 
     /// <summary>Change style from current styling position for length characters to a style
     /// and move the current styling position to after this newly styled segment.</summary>
-    procedure SetStyling(ALength: Integer; AStyle: Integer);
+    procedure SetStyling(ALength: NativeInt; AStyle: Integer);
 
     /// <summary>Set the symbol used for a particular marker number.</summary>
     procedure MarkerDefine(AMarkerNumber: Integer; AMarkerSymbol: Integer);
@@ -86,29 +86,29 @@
     procedure MarkerEnableHighlight(AEnabled: Boolean);
 
     /// <summary>Add a marker to a line, returning an ID which can be used to find or delete the marker.</summary>
-    function MarkerAdd(ALine: Integer; AMarkerNumber: Integer): Integer;
+    function MarkerAdd(ALine: NativeInt; AMarkerNumber: Integer): Integer;
 
     /// <summary>Delete a marker from a line.</summary>
-    procedure MarkerDelete(ALine: Integer; AMarkerNumber: Integer);
+    procedure MarkerDelete(ALine: NativeInt; AMarkerNumber: Integer);
 
     /// <summary>Delete all markers with a particular number from all lines.</summary>
     procedure MarkerDeleteAll(AMarkerNumber: Integer);
 
     /// <summary>Get a bit mask of all the markers set on a line.</summary>
-    function MarkerGet(ALine: Integer): Integer;
+    function MarkerGet(ALine: NativeInt): Integer;
 
     /// <summary>Find the next line at or after lineStart that includes a marker in mask.
     /// Return -1 when no more lines.</summary>
-    function MarkerNext(ALineStart: Integer; AMarkerMask: Integer): Integer;
+    function MarkerNext(ALineStart: NativeInt; AMarkerMask: Integer): NativeInt;
 
     /// <summary>Find the previous line before lineStart that includes a marker in mask.</summary>
-    function MarkerPrevious(ALineStart: Integer; AMarkerMask: Integer): Integer;
+    function MarkerPrevious(ALineStart: NativeInt; AMarkerMask: Integer): NativeInt;
 
     /// <summary>Define a marker from a pixmap.</summary>
     procedure MarkerDefinePixmap(AMarkerNumber: Integer; const APixmap: TBytes);
 
     /// <summary>Add a set of markers to a line.</summary>
-    procedure MarkerAddSet(ALine: Integer; ASet: Integer);
+    procedure MarkerAddSet(ALine: NativeInt; ASet: Integer);
 
     /// <summary>Set the alpha used for a marker that is drawn in the text area, not the margin.</summary>
     procedure MarkerSetAlpha(AMarkerNumber: Integer; AAlpha: Integer);
@@ -157,7 +157,7 @@
     /// <summary>Display a auto-completion list.
     /// The lenEntered parameter indicates how many characters before
     /// the caret should be used to provide context.</summary>
-    procedure AutoCShow(ALenEntered: Integer; const AItemList: UnicodeString);
+    procedure AutoCShow(ALenEntered: NativeInt; const AItemList: UnicodeString);
 
     /// <summary>Remove the auto-completion list from the screen.</summary>
     procedure AutoCCancel;
@@ -166,7 +166,7 @@
     function AutoCActive: Boolean;
 
     /// <summary>Retrieve the position of the caret when the auto-completion list was displayed.</summary>
-    function AutoCPosStart: Integer;
+    function AutoCPosStart: NativeInt;
 
     /// <summary>User has selected an item so remove the list and insert the selection.</summary>
     procedure AutoCComplete;
@@ -187,23 +187,23 @@
     procedure ClearRegisteredImages;
 
     /// <summary>Count characters between two positions.</summary>
-    function CountCharacters(AStartPos: Integer; AEndPos: Integer): Integer;
+    function CountCharacters(AStartPos: NativeInt; AEndPos: NativeInt): NativeInt;
 
     /// <summary>Set caret to a position, while removing any existing selection.</summary>
-    procedure SetEmptySelection(APos: Integer);
+    procedure SetEmptySelection(APos: NativeInt);
 
     /// <summary>Find some text in the document.</summary>
-    function FindText(AFlags: Integer; const AText: UnicodeString; var ARange: TDSciCharacterRange): Integer;
+    function FindText(AFlags: Integer; const AText: UnicodeString; var ARange: TDSciCharacterRange): NativeInt;
 
     /// <summary>On Windows, will draw the document into a display context such as a printer.</summary>
-    function FormatRange(ADraw: Boolean; var AFr: TDSciRangeToFormat): Integer;
+    function FormatRange(ADraw: Boolean; var AFr: TDSciRangeToFormat): NativeInt;
 
     /// <summary>Retrieve the contents of a line.
     /// Returns the length of the line.</summary>
-    function GetLine(ALine: Integer): UnicodeString;
+    function GetLine(ALine: NativeInt): UnicodeString;
 
     /// <summary>Select a range of text.</summary>
-    procedure SetSel(AStart: Integer; AEnd: Integer);
+    procedure SetSel(AStart: NativeInt; AEnd: NativeInt);
 
     /// <summary>Retrieve the selected text.
     /// Return the length of the text.</summary>
@@ -211,25 +211,25 @@
 
     /// <summary>Retrieve a range of text.
     /// Return the length of the text.</summary>
-    function GetTextRange(AStart, AEnd: Integer): UnicodeString;
+    function GetTextRange(AStart, AEnd: NativeInt): UnicodeString;
 
     /// <summary>Draw the selection in normal style or with selection highlighted.</summary>
     procedure HideSelection(ANormal: Boolean);
 
     /// <summary>Retrieve the x value of the point in the window where a position is displayed.</summary>
-    function PointXFromPosition(APos: Integer): Integer;
+    function PointXFromPosition(APos: NativeInt): Integer;
 
     /// <summary>Retrieve the y value of the point in the window where a position is displayed.</summary>
-    function PointYFromPosition(APos: Integer): Integer;
+    function PointYFromPosition(APos: NativeInt): Integer;
 
     /// <summary>Retrieve the line containing a position.</summary>
-    function LineFromPosition(APos: Integer): Integer;
+    function LineFromPosition(APos: NativeInt): NativeInt;
 
     /// <summary>Retrieve the position at the start of a line.</summary>
-    function PositionFromLine(ALine: Integer): Integer;
+    function PositionFromLine(ALine: NativeInt): NativeInt;
 
     /// <summary>Scroll horizontally and vertically.</summary>
-    procedure LineScroll(AColumns: Integer; ALines: Integer);
+    procedure LineScroll(AColumns: NativeInt; ALines: NativeInt);
 
     /// <summary>Ensure the caret is visible.</summary>
     procedure ScrollCaret;
@@ -237,7 +237,7 @@
     /// <summary>Scroll the argument positions and the range between them into view giving
     /// priority to the primary position then the secondary position.
     /// This may be used to make a search match visible.</summary>
-    procedure ScrollRange(ASecondary: Integer; APrimary: Integer);
+    procedure ScrollRange(ASecondary: NativeInt; APrimary: NativeInt);
 
     /// <summary>Replace the selected text with the argument text.</summary>
     procedure ReplaceSel(const AText: UnicodeString);
@@ -279,7 +279,7 @@
     /// <summary>Replace the target text with the argument text.
     /// Text is counted so it can contain NULs.
     /// Returns the length of the replacement text.</summary>
-    function ReplaceTarget(const AText: UnicodeString): Integer;
+    function ReplaceTarget(const AText: UnicodeString): NativeInt;
 
     /// <summary>Replace the target text with the argument text after \d processing.
     /// Text is counted so it can contain NULs.
@@ -287,15 +287,15 @@
     /// matched in the last search operation which were surrounded by \( and \).
     /// Returns the length of the replacement text including any change
     /// caused by processing the \d patterns.</summary>
-    function ReplaceTargetRE(const AText: UnicodeString): Integer;
+    function ReplaceTargetRE(const AText: UnicodeString): NativeInt;
 
     /// <summary>Search for a counted string in the target and set the target to the found
     /// range. Text is counted so it can contain NULs.
     /// Returns length of range or -1 for failure in which case target is not moved.</summary>
-    function SearchInTarget(const AText: UnicodeString): Integer;
+    function SearchInTarget(const AText: UnicodeString): NativeInt;
 
     /// <summary>Show a call tip containing a definition near position pos.</summary>
-    procedure CallTipShow(APos: Integer; const ADefinition: UnicodeString);
+    procedure CallTipShow(APos: NativeInt; const ADefinition: UnicodeString);
 
     /// <summary>Remove the call tip from the screen.</summary>
     procedure CallTipCancel;
@@ -304,56 +304,56 @@
     function CallTipActive: Boolean;
 
     /// <summary>Retrieve the position where the caret was before displaying the call tip.</summary>
-    function CallTipPosStart: Integer;
+    function CallTipPosStart: NativeInt;
 
     /// <summary>Highlight a segment of the definition.</summary>
     procedure CallTipSetHlt(AStart: Integer; AEnd: Integer);
 
     /// <summary>Find the display line of a document line taking hidden lines into account.</summary>
-    function VisibleFromDocLine(ALine: Integer): Integer;
+    function VisibleFromDocLine(ALine: NativeInt): NativeInt;
 
     /// <summary>Find the document line of a display line taking hidden lines into account.</summary>
-    function DocLineFromVisible(ALineDisplay: Integer): Integer;
+    function DocLineFromVisible(ALineDisplay: NativeInt): NativeInt;
 
     /// <summary>The number of display lines needed to wrap a document line</summary>
-    function WrapCount(ALine: Integer): Integer;
+    function WrapCount(ALine: NativeInt): NativeInt;
 
     /// <summary>Make a range of lines visible.</summary>
-    procedure ShowLines(ALineStart: Integer; ALineEnd: Integer);
+    procedure ShowLines(ALineStart: NativeInt; ALineEnd: NativeInt);
 
     /// <summary>Make a range of lines invisible.</summary>
-    procedure HideLines(ALineStart: Integer; ALineEnd: Integer);
+    procedure HideLines(ALineStart: NativeInt; ALineEnd: NativeInt);
 
     /// <summary>Switch a header line between expanded and contracted.</summary>
-    procedure ToggleFold(ALine: Integer);
+    procedure ToggleFold(ALine: NativeInt);
 
     /// <summary>Expand or contract a fold header.</summary>
-    procedure FoldLine(ALine: Integer; AAction: Integer);
+    procedure FoldLine(ALine: NativeInt; AAction: Integer);
 
     /// <summary>Expand or contract a fold header and its children.</summary>
-    procedure FoldChildren(ALine: Integer; AAction: Integer);
+    procedure FoldChildren(ALine: NativeInt; AAction: Integer);
 
     /// <summary>Expand a fold header and all children. Use the level argument instead of the line's current level.</summary>
-    procedure ExpandChildren(ALine: Integer; ALevel: Integer);
+    procedure ExpandChildren(ALine: NativeInt; ALevel: Integer);
 
     /// <summary>Expand or contract all fold headers.</summary>
     procedure FoldAll(AAction: Integer);
 
     /// <summary>Ensure a particular line is visible by expanding any header line hiding it.</summary>
-    procedure EnsureVisible(ALine: Integer);
+    procedure EnsureVisible(ALine: NativeInt);
 
     /// <summary>Set some style options for folding.</summary>
     procedure SetFoldFlags(AFlags: Integer);
 
     /// <summary>Ensure a particular line is visible by expanding any header line hiding it.
     /// Use the currently set visibility policy to determine which range to display.</summary>
-    procedure EnsureVisibleEnforcePolicy(ALine: Integer);
+    procedure EnsureVisibleEnforcePolicy(ALine: NativeInt);
 
     /// <summary>Get position of start of word.</summary>
-    function WordStartPosition(APos: Integer; AOnlyWordCharacters: Boolean): Integer;
+    function WordStartPosition(APos: NativeInt; AOnlyWordCharacters: Boolean): NativeInt;
 
     /// <summary>Get position of end of word.</summary>
-    function WordEndPosition(APos: Integer; AOnlyWordCharacters: Boolean): Integer;
+    function WordEndPosition(APos: NativeInt; AOnlyWordCharacters: Boolean): NativeInt;
 
     /// <summary>Measure the pixel width of some text in a particular style.
     /// NUL terminated text argument.
@@ -361,7 +361,7 @@
     function TextWidth(AStyle: Integer; const AText: UnicodeString): Integer;
 
     /// <summary>Retrieve the height of a particular line of text in pixels.</summary>
-    function TextHeight(ALine: Integer): Integer;
+    function TextHeight(ALine: NativeInt): Integer;
 
     /// <summary>Append a string to the end of the document without changing the selection.</summary>
     procedure AppendText(const AText: UnicodeString);
@@ -561,36 +561,36 @@
     procedure MoveCaretInsideView;
 
     /// <summary>How many characters are on a line, including end of line characters?</summary>
-    function LineLength(ALine: Integer): Integer;
+    function LineLength(ALine: NativeInt): NativeInt;
 
     /// <summary>Highlight the characters at two positions.</summary>
-    procedure BraceHighlight(APos1: Integer; APos2: Integer);
+    procedure BraceHighlight(APos1: NativeInt; APos2: NativeInt);
 
     /// <summary>Use specified indicator to highlight matching braces instead of changing their style.</summary>
     procedure BraceHighlightIndicator(AUseBraceHighlightIndicator: Boolean; AIndicator: Integer);
 
     /// <summary>Highlight the character at a position indicating there is no matching brace.</summary>
-    procedure BraceBadLight(APos: Integer);
+    procedure BraceBadLight(APos: NativeInt);
 
     /// <summary>Use specified indicator to highlight non matching brace instead of changing its style.</summary>
     procedure BraceBadLightIndicator(AUseBraceBadLightIndicator: Boolean; AIndicator: Integer);
 
     /// <summary>Find the position of a matching brace or INVALID_POSITION if no match.</summary>
-    function BraceMatch(APos: Integer): Integer;
+    function BraceMatch(APos: NativeInt): Integer;
 
     /// <summary>Sets the current caret position to be the search anchor.</summary>
     procedure SearchAnchor;
 
     /// <summary>Find some text starting at the search anchor.
     /// Does not ensure the selection is visible.</summary>
-    function SearchNext(AFlags: Integer; const AText: UnicodeString): Integer;
+    function SearchNext(AFlags: Integer; const AText: UnicodeString): NativeInt;
 
     /// <summary>Find some text starting at the search anchor and moving backwards.
     /// Does not ensure the selection is visible.</summary>
-    function SearchPrev(AFlags: Integer; const AText: UnicodeString): Integer;
+    function SearchPrev(AFlags: Integer; const AText: UnicodeString): NativeInt;
 
     /// <summary>Retrieves the number of lines completely visible.</summary>
-    function LinesOnScreen: Integer;
+    function LinesOnScreen: NativeInt;
 
     /// <summary>Set whether a pop up menu is displayed automatically when the user presses
     /// the wrong mouse button.</summary>
@@ -658,27 +658,27 @@
 
     /// <summary>Given a valid document position, return the previous position taking code
     /// page into account. Returns 0 if passed 0.</summary>
-    function PositionBefore(APos: Integer): Integer;
+    function PositionBefore(APos: NativeInt): NativeInt;
 
     /// <summary>Given a valid document position, return the next position taking code
     /// page into account. Maximum value returned is the last position in the document.</summary>
-    function PositionAfter(APos: Integer): Integer;
+    function PositionAfter(APos: NativeInt): NativeInt;
 
     /// <summary>Given a valid document position, return a position that differs in a number
     /// of characters. Returned value is always between 0 and last position in document.</summary>
-    function PositionRelative(APos: Integer; ARelative: Integer): Integer;
+    function PositionRelative(APos: NativeInt; ARelative: NativeInt): NativeInt;
 
     /// <summary>Copy a range of text to the clipboard. Positions are clipped into the document.</summary>
-    procedure CopyRange(AStart: Integer; AEnd: Integer);
+    procedure CopyRange(AStart: NativeInt; AEnd: NativeInt);
 
     /// <summary>Copy argument text to the clipboard.</summary>
     procedure CopyText(const AText: UnicodeString);
 
     /// <summary>Retrieve the position of the start of the selection at the given line (INVALID_POSITION if no selection on this line).</summary>
-    function GetLineSelStartPosition(ALine: Integer): Integer;
+    function GetLineSelStartPosition(ALine: NativeInt): NativeInt;
 
     /// <summary>Retrieve the position of the end of the selection at the given line (INVALID_POSITION if no selection on this line).</summary>
-    function GetLineSelEndPosition(ALine: Integer): Integer;
+    function GetLineSelEndPosition(ALine: NativeInt): NativeInt;
 
     /// <summary>Move caret down one line, extending rectangular selection to new caret position.</summary>
     procedure LineDownRectExtend;
@@ -744,7 +744,7 @@
     function AutoCGetCurrentText: UnicodeString;
 
     /// <summary>Enlarge the document to a particular size of text bytes.</summary>
-    procedure Allocate(ABytes: Integer);
+    procedure Allocate(ABytes: NativeInt);
 
     /// <summary>Returns the target converted to UTF8.
     /// Return the length in bytes.</summary>
@@ -761,7 +761,7 @@
 
     /// <summary>Find the position of a column on a line taking into account tabs and
     /// multi-byte characters. If beyond end of line, return line end position.</summary>
-    function FindColumn(ALine: Integer; AColumn: Integer): Integer;
+    function FindColumn(ALine: NativeInt; AColumn: NativeInt): NativeInt;
 
     /// <summary>Switch between sticky and non-sticky: meant to be bound to a key.</summary>
     procedure ToggleCaretSticky;
@@ -770,29 +770,29 @@
     procedure SelectionDuplicate;
 
     /// <summary>Turn a indicator on over a range.</summary>
-    procedure IndicatorFillRange(APosition: Integer; AFillLength: Integer);
+    procedure IndicatorFillRange(APosition: NativeInt; AFillLength: NativeInt);
 
     /// <summary>Turn a indicator off over a range.</summary>
-    procedure IndicatorClearRange(APosition: Integer; AClearLength: Integer);
+    procedure IndicatorClearRange(APosition: NativeInt; AClearLength: NativeInt);
 
     /// <summary>Are any indicators present at position?</summary>
-    function IndicatorAllOnFor(APosition: Integer): Integer;
+    function IndicatorAllOnFor(APosition: NativeInt): Integer;
 
     /// <summary>What value does a particular indicator have at at a position?</summary>
-    function IndicatorValueAt(AIndicator: Integer; APosition: Integer): Integer;
+    function IndicatorValueAt(AIndicator: Integer; APosition: NativeInt): Integer;
 
     /// <summary>Where does a particular indicator start?</summary>
-    function IndicatorStart(AIndicator: Integer; APosition: Integer): Integer;
+    function IndicatorStart(AIndicator: Integer; APosition: NativeInt): NativeInt;
 
     /// <summary>Where does a particular indicator end?</summary>
-    function IndicatorEnd(AIndicator: Integer; APosition: Integer): Integer;
+    function IndicatorEnd(AIndicator: Integer; APosition: NativeInt): NativeInt;
 
     /// <summary>Copy the selection, if selection empty copy the line with the caret</summary>
     procedure CopyAllowLine;
 
     /// <summary>Return a position which, to avoid performance costs, should not be within
     /// the range of a call to GetRangePointer.</summary>
-    function GetGapPosition: Integer;
+    function GetGapPosition: NativeInt;
 
     /// <summary>Which symbol was defined for markerNumber with MarkerDefine</summary>
     function MarkerSymbolDefined(AMarkerNumber: Integer): Integer;
@@ -813,23 +813,23 @@
     procedure AddUndoAction(AToken: Integer; AFlags: Integer);
 
     /// <summary>Find the position of a character from a point within the window.</summary>
-    function CharPositionFromPoint(AX: Integer; AY: Integer): Integer;
+    function CharPositionFromPoint(AX: Integer; AY: Integer): NativeInt;
 
     /// <summary>Find the position of a character from a point within the window.
     /// Return INVALID_POSITION if not close to text.</summary>
-    function CharPositionFromPointClose(AX: Integer; AY: Integer): Integer;
+    function CharPositionFromPointClose(AX: Integer; AY: Integer): NativeInt;
 
     /// <summary>Clear selections to a single empty stream selection</summary>
     procedure ClearSelections;
 
     /// <summary>Set a simple selection</summary>
-    function SetSelection(ACaret: Integer; AAnchor: Integer): Integer;
+    function SetSelection(ACaret: NativeInt; AAnchor: NativeInt): Integer;
 
     /// <summary>Add a selection</summary>
-    function AddSelection(ACaret: Integer; AAnchor: Integer): Integer;
+    function AddSelection(ACaret: NativeInt; AAnchor: NativeInt): Integer;
 
     /// <summary>Drop one selection</summary>
-    procedure DropSelectionN(ASelection: Integer);
+    procedure DropSelectionN(ASelection: NativeInt);
 
     /// <summary>Set the main selection to the next selection.</summary>
     procedure RotateSelection;
@@ -839,11 +839,11 @@
 
     /// <summary>Indicate that the internal state of a lexer has changed over a range and therefore
     /// there may be a need to redraw.</summary>
-    function ChangeLexerState(AStart: Integer; AEnd: Integer): Integer;
+    function ChangeLexerState(AStart: NativeInt; AEnd: NativeInt): Integer;
 
     /// <summary>Find the next line at or after lineStart that is a contracted fold header line.
     /// Return -1 when no more lines.</summary>
-    function ContractedFoldNext(ALineStart: Integer): Integer;
+    function ContractedFoldNext(ALineStart: NativeInt): NativeInt;
 
     /// <summary>Centre current line in window.</summary>
     procedure VerticalCentreCaret;
@@ -872,7 +872,7 @@
     procedure ScrollToEnd;
 
     /// <summary>Create an ILoader*.</summary>
-    function CreateLoader(ABytes: Integer): Pointer;
+    function CreateLoader(ABytes: NativeInt): Pointer;
 
     /// <summary>On OS X, show a find indicator.</summary>
     // procedure FindIndicatorShow(AStart: Integer; AEnd: Integer);
@@ -900,7 +900,7 @@
     procedure StopRecord;
 
     /// <summary>Colourise a segment of the document using the current lexing language.</summary>
-    procedure Colourise(AStart: Integer; AEnd: Integer);
+    procedure Colourise(AStart: NativeInt; AEnd: NativeInt);
 
     /// <summary>Set up the key words used by the lexer.</summary>
     procedure SetKeyWords(AKeywordSet: Integer; const AKeyWords: UnicodeString);
@@ -919,7 +919,7 @@
     function GetPropertyExpanded(const AKey: UnicodeString): UnicodeString;
 
     /// <summary>For private communication between an application and a known lexer.</summary>
-    function PrivateLexerCall(AOperation: Integer; APointer: Integer): Integer;
+    function PrivateLexerCall(AOperation: Integer; APointer: Pointer): NativeInt;
 
     /// <summary>Retrieve a '\n' separated list of properties understood by the current lexer.</summary>
     function PropertyNames: UnicodeString;

--- a/Sources/DScintillaPropertiesCode.inc
+++ b/Sources/DScintillaPropertiesCode.inc
@@ -1,24 +1,24 @@
-function TDScintilla.GetLength: Integer;
+function TDScintilla.GetLength: NativeInt;
 begin
   Result := SendEditor(SCI_GETLENGTH, 0, 0);
 end;
 
-function TDScintilla.GetCharAt(APos: Integer): Integer;
+function TDScintilla.GetCharAt(APos: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_GETCHARAT, APos, 0);
 end;
 
-function TDScintilla.GetCurrentPos: Integer;
+function TDScintilla.GetCurrentPos: NativeInt;
 begin
   Result := SendEditor(SCI_GETCURRENTPOS, 0, 0);
 end;
 
-function TDScintilla.GetAnchor: Integer;
+function TDScintilla.GetAnchor: NativeInt;
 begin
   Result := SendEditor(SCI_GETANCHOR, 0, 0);
 end;
 
-function TDScintilla.GetStyleAt(APos: Integer): Integer;
+function TDScintilla.GetStyleAt(APos: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_GETSTYLEAT, APos, 0);
 end;
@@ -43,12 +43,12 @@ begin
   SendEditor(SCI_SETVIEWWS, AViewWS, 0);
 end;
 
-procedure TDScintilla.SetAnchor(APosAnchor: Integer);
+procedure TDScintilla.SetAnchor(APosAnchor: NativeInt);
 begin
   SendEditor(SCI_SETANCHOR, APosAnchor, 0);
 end;
 
-function TDScintilla.GetEndStyled: Integer;
+function TDScintilla.GetEndStyled: NativeInt;
 begin
   Result := SendEditor(SCI_GETENDSTYLED, 0, 0);
 end;
@@ -373,17 +373,17 @@ begin
   Result := SendEditor(SCI_GETSTYLEBITS, 0, 0);
 end;
 
-procedure TDScintilla.SetLineState(ALine: Integer; AState: Integer);
+procedure TDScintilla.SetLineState(ALine: NativeInt; AState: Integer);
 begin
   SendEditor(SCI_SETLINESTATE, ALine, AState);
 end;
 
-function TDScintilla.GetLineState(ALine: Integer): Integer;
+function TDScintilla.GetLineState(ALine: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_GETLINESTATE, ALine, 0);
 end;
 
-function TDScintilla.GetMaxLineState: Integer;
+function TDScintilla.GetMaxLineState: NativeInt;
 begin
   Result := SendEditor(SCI_GETMAXLINESTATE, 0, 0);
 end;
@@ -528,22 +528,22 @@ begin
   Result := Boolean(SendEditor(SCI_GETUSETABS, 0, 0));
 end;
 
-procedure TDScintilla.SetLineIndentation(ALine: Integer; AIndentSize: Integer);
+procedure TDScintilla.SetLineIndentation(ALine: NativeInt; AIndentSize: Integer);
 begin
   SendEditor(SCI_SETLINEINDENTATION, ALine, AIndentSize);
 end;
 
-function TDScintilla.GetLineIndentation(ALine: Integer): Integer;
+function TDScintilla.GetLineIndentation(ALine: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_GETLINEINDENTATION, ALine, 0);
 end;
 
-function TDScintilla.GetLineIndentPosition(ALine: Integer): Integer;
+function TDScintilla.GetLineIndentPosition(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_GETLINEINDENTPOSITION, ALine, 0);
 end;
 
-function TDScintilla.GetColumn(APos: Integer): Integer;
+function TDScintilla.GetColumn(APos: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_GETCOLUMN, APos, 0);
 end;
@@ -578,7 +578,7 @@ begin
   Result := SendEditor(SCI_GETHIGHLIGHTGUIDE, 0, 0);
 end;
 
-function TDScintilla.GetLineEndPosition(ALine: Integer): Integer;
+function TDScintilla.GetLineEndPosition(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_GETLINEENDPOSITION, ALine, 0);
 end;
@@ -598,27 +598,27 @@ begin
   Result := Boolean(SendEditor(SCI_GETREADONLY, 0, 0));
 end;
 
-procedure TDScintilla.SetCurrentPos(APos: Integer);
+procedure TDScintilla.SetCurrentPos(APos: NativeInt);
 begin
   SendEditor(SCI_SETCURRENTPOS, APos, 0);
 end;
 
-procedure TDScintilla.SetSelectionStart(APos: Integer);
+procedure TDScintilla.SetSelectionStart(APos: NativeInt);
 begin
   SendEditor(SCI_SETSELECTIONSTART, APos, 0);
 end;
 
-function TDScintilla.GetSelectionStart: Integer;
+function TDScintilla.GetSelectionStart: NativeInt;
 begin
   Result := SendEditor(SCI_GETSELECTIONSTART, 0, 0);
 end;
 
-procedure TDScintilla.SetSelectionEnd(APos: Integer);
+procedure TDScintilla.SetSelectionEnd(APos: NativeInt);
 begin
   SendEditor(SCI_SETSELECTIONEND, APos, 0);
 end;
 
-function TDScintilla.GetSelectionEnd: Integer;
+function TDScintilla.GetSelectionEnd: NativeInt;
 begin
   Result := SendEditor(SCI_GETSELECTIONEND, 0, 0);
 end;
@@ -643,12 +643,12 @@ begin
   Result := SendEditor(SCI_GETPRINTCOLOURMODE, 0, 0);
 end;
 
-function TDScintilla.GetFirstVisibleLine: Integer;
+function TDScintilla.GetFirstVisibleLine: NativeInt;
 begin
   Result := SendEditor(SCI_GETFIRSTVISIBLELINE, 0, 0);
 end;
 
-function TDScintilla.GetLineCount: Integer;
+function TDScintilla.GetLineCount: NativeInt;
 begin
   Result := SendEditor(SCI_GETLINECOUNT, 0, 0);
 end;
@@ -683,7 +683,7 @@ begin
   SendEditor(SCI_SETREADONLY, Integer(AReadOnly), 0);
 end;
 
-function TDScintilla.GetTextLength: Integer;
+function TDScintilla.GetTextLength: NativeInt;
 begin
   Result := SendEditor(SCI_GETTEXTLENGTH, 0, 0);
 end;
@@ -718,22 +718,22 @@ begin
   Result := SendEditor(SCI_GETCARETWIDTH, 0, 0);
 end;
 
-procedure TDScintilla.SetTargetStart(APos: Integer);
+procedure TDScintilla.SetTargetStart(APos: NativeInt);
 begin
   SendEditor(SCI_SETTARGETSTART, APos, 0);
 end;
 
-function TDScintilla.GetTargetStart: Integer;
+function TDScintilla.GetTargetStart: NativeInt;
 begin
   Result := SendEditor(SCI_GETTARGETSTART, 0, 0);
 end;
 
-procedure TDScintilla.SetTargetEnd(APos: Integer);
+procedure TDScintilla.SetTargetEnd(APos: NativeInt);
 begin
   SendEditor(SCI_SETTARGETEND, APos, 0);
 end;
 
-function TDScintilla.GetTargetEnd: Integer;
+function TDScintilla.GetTargetEnd: NativeInt;
 begin
   Result := SendEditor(SCI_GETTARGETEND, 0, 0);
 end;
@@ -748,7 +748,7 @@ begin
   Result := SendEditor(SCI_GETSEARCHFLAGS, 0, 0);
 end;
 
-procedure TDScintilla.CallTipSetPosStart(APosStart: Integer);
+procedure TDScintilla.CallTipSetPosStart(APosStart: NativeInt);
 begin
   SendEditor(SCI_CALLTIPSETPOSSTART, APosStart, 0);
 end;
@@ -778,27 +778,27 @@ begin
   SendEditor(SCI_CALLTIPSETPOSITION, Integer(AAbove), 0);
 end;
 
-procedure TDScintilla.SetFoldLevel(ALine: Integer; ALevel: Integer);
+procedure TDScintilla.SetFoldLevel(ALine: NativeInt; ALevel: Integer);
 begin
   SendEditor(SCI_SETFOLDLEVEL, ALine, ALevel);
 end;
 
-function TDScintilla.GetFoldLevel(ALine: Integer): Integer;
+function TDScintilla.GetFoldLevel(ALine: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_GETFOLDLEVEL, ALine, 0);
 end;
 
-function TDScintilla.GetLastChild(ALine: Integer; ALevel: Integer): Integer;
+function TDScintilla.GetLastChild(ALine: NativeInt; ALevel: Integer): NativeInt;
 begin
   Result := SendEditor(SCI_GETLASTCHILD, ALine, ALevel);
 end;
 
-function TDScintilla.GetFoldParent(ALine: Integer): Integer;
+function TDScintilla.GetFoldParent(ALine: NativeInt): NativeInt;
 begin
   Result := SendEditor(SCI_GETFOLDPARENT, ALine, 0);
 end;
 
-function TDScintilla.GetLineVisible(ALine: Integer): Boolean;
+function TDScintilla.GetLineVisible(ALine: NativeInt): Boolean;
 begin
   Result := Boolean(SendEditor(SCI_GETLINEVISIBLE, ALine, 0));
 end;
@@ -808,12 +808,12 @@ begin
   Result := Boolean(SendEditor(SCI_GETALLLINESVISIBLE, 0, 0));
 end;
 
-procedure TDScintilla.SetFoldExpanded(ALine: Integer; AExpanded: Boolean);
+procedure TDScintilla.SetFoldExpanded(ALine: NativeInt; AExpanded: Boolean);
 begin
   SendEditor(SCI_SETFOLDEXPANDED, ALine, Integer(AExpanded));
 end;
 
-function TDScintilla.GetFoldExpanded(ALine: Integer): Boolean;
+function TDScintilla.GetFoldExpanded(ALine: NativeInt): Boolean;
 begin
   Result := Boolean(SendEditor(SCI_GETFOLDEXPANDED, ALine, 0));
 end;
@@ -978,7 +978,7 @@ begin
   Result := SendEditor(SCI_GETFONTQUALITY, 0, 0);
 end;
 
-procedure TDScintilla.SetFirstVisibleLine(ALineDisplay: Integer);
+procedure TDScintilla.SetFirstVisibleLine(ALineDisplay: NativeInt);
 begin
   SendEditor(SCI_SETFIRSTVISIBLELINE, ALineDisplay, 0);
 end;
@@ -1284,12 +1284,12 @@ begin
   Result := SendEditor(SCI_GETINDICATORVALUE, 0, 0);
 end;
 
-procedure TDScintilla.SetPositionCache(ASize: Integer);
+procedure TDScintilla.SetPositionCache(ASize: NativeInt);
 begin
   SendEditor(SCI_SETPOSITIONCACHE, ASize, 0);
 end;
 
-function TDScintilla.GetPositionCache: Integer;
+function TDScintilla.GetPositionCache: NativeInt;
 begin
   Result := SendEditor(SCI_GETPOSITIONCACHE, 0, 0);
 end;
@@ -1299,7 +1299,7 @@ begin
   Result := PByte(SendEditor(SCI_GETCHARACTERPOINTER, 0, 0));
 end;
 
-function TDScintilla.GetRangePointer(APosition: Integer; ARangeLength: Integer): Pointer;
+function TDScintilla.GetRangePointer(APosition: NativeInt; ARangeLength: NativeInt): Pointer;
 begin
   Result := Pointer(SendEditor(SCI_GETRANGEPOINTER, APosition, ARangeLength));
 end;
@@ -1354,32 +1354,32 @@ begin
   Result := SendEditor(SCI_GETEXTRADESCENT, 0, 0);
 end;
 
-procedure TDScintilla.MarginSetText(ALine: Integer; const AText: UnicodeString);
+procedure TDScintilla.MarginSetText(ALine: NativeInt; const AText: UnicodeString);
 begin
   FHelper.SetText(SCI_MARGINSETTEXT, ALine, AText);
 end;
 
-function TDScintilla.MarginGetText(ALine: Integer): UnicodeString;
+function TDScintilla.MarginGetText(ALine: NativeInt): UnicodeString;
 begin
   FHelper.GetText(SCI_MARGINGETTEXT, ALine, Result);
 end;
 
-procedure TDScintilla.MarginSetStyle(ALine: Integer; AStyle: Integer);
+procedure TDScintilla.MarginSetStyle(ALine: NativeInt; AStyle: Integer);
 begin
   SendEditor(SCI_MARGINSETSTYLE, ALine, AStyle);
 end;
 
-function TDScintilla.MarginGetStyle(ALine: Integer): Integer;
+function TDScintilla.MarginGetStyle(ALine: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_MARGINGETSTYLE, ALine, 0);
 end;
 
-procedure TDScintilla.MarginSetStyles(ALine: Integer; const AStyles: TDSciStyles);
+procedure TDScintilla.MarginSetStyles(ALine: NativeInt; const AStyles: TDSciStyles);
 begin
   SendEditor(SCI_MARGINSETSTYLES, ALine, Integer(AStyles));
 end;
 
-function TDScintilla.MarginGetStyles(ALine: Integer): TDSciStyles;
+function TDScintilla.MarginGetStyles(ALine: NativeInt): TDSciStyles;
 begin
   SetLength(Result, SendEditor(SCI_MARGINGETSTYLES, ALine));
   if Length(Result) > 0 then
@@ -1406,38 +1406,38 @@ begin
   Result := SendEditor(SCI_GETMARGINOPTIONS, 0, 0);
 end;
 
-procedure TDScintilla.AnnotationSetText(ALine: Integer; const AText: UnicodeString);
+procedure TDScintilla.AnnotationSetText(ALine: NativeInt; const AText: UnicodeString);
 begin
   FHelper.SetText(SCI_ANNOTATIONSETTEXT, ALine, AText);
 end;
 
-function TDScintilla.AnnotationGetText(ALine: Integer): UnicodeString;
+function TDScintilla.AnnotationGetText(ALine: NativeInt): UnicodeString;
 begin
   FHelper.SetText(SCI_ANNOTATIONGETTEXT, ALine, Result);
 end;
-procedure TDScintilla.AnnotationSetStyle(ALine: Integer; AStyle: Integer);
+procedure TDScintilla.AnnotationSetStyle(ALine: NativeInt; AStyle: Integer);
 begin
   SendEditor(SCI_ANNOTATIONSETSTYLE, ALine, AStyle);
 end;
 
-function TDScintilla.AnnotationGetStyle(ALine: Integer): Integer;
+function TDScintilla.AnnotationGetStyle(ALine: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_ANNOTATIONGETSTYLE, ALine, 0);
 end;
 
-procedure TDScintilla.AnnotationSetStyles(ALine: Integer; const AStyles: TDSciStyles);
+procedure TDScintilla.AnnotationSetStyles(ALine: NativeInt; const AStyles: TDSciStyles);
 begin
   SendEditor(SCI_ANNOTATIONSETSTYLES, ALine, Integer(AStyles));
 end;
 
-function TDScintilla.AnnotationGetStyles(ALine: Integer): TDSciStyles;
+function TDScintilla.AnnotationGetStyles(ALine: NativeInt): TDSciStyles;
 begin
   SetLength(Result, SendEditor(SCI_ANNOTATIONGETSTYLES, ALine));
   if Length(Result) > 0 then
     SendEditor(SCI_ANNOTATIONGETSTYLES, ALine, Integer(Result));
 end;
 
-function TDScintilla.AnnotationGetLines(ALine: Integer): Integer;
+function TDScintilla.AnnotationGetLines(ALine: NativeInt): Integer;
 begin
   Result := SendEditor(SCI_ANNOTATIONGETLINES, ALine, 0);
 end;
@@ -1512,7 +1512,7 @@ begin
   Result := Boolean(SendEditor(SCI_GETADDITIONALCARETSVISIBLE, 0, 0));
 end;
 
-function TDScintilla.GetSelections: Integer;
+function TDScintilla.GetSelections: NativeInt;
 begin
   Result := SendEditor(SCI_GETSELECTIONS, 0, 0);
 end;
@@ -1522,23 +1522,23 @@ begin
   Result := Boolean(SendEditor(SCI_GETSELECTIONEMPTY, 0, 0));
 end;
 
-procedure TDScintilla.SetMainSelection(ASelection: Integer);
+procedure TDScintilla.SetMainSelection(ASelection: NativeInt);
 begin
   SendEditor(SCI_SETMAINSELECTION, ASelection, 0);
 end;
 
-function TDScintilla.GetMainSelection: Integer;
+function TDScintilla.GetMainSelection: NativeInt;
 begin
   Result := SendEditor(SCI_GETMAINSELECTION, 0, 0);
 end;
 
-procedure TDScintilla.SetSelectionNCaret(ASelection: Integer; APos: Integer);
+procedure TDScintilla.SetSelectionNCaret(ASelection: NativeInt; APos: NativeInt);
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     SendEditor(SCI_SETSELECTIONNCARET, ASelection, APos);
 end;
 
-function TDScintilla.GetSelectionNCaret(ASelection: Integer): Integer;
+function TDScintilla.GetSelectionNCaret(ASelection: NativeInt): NativeInt;
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     Result := SendEditor(SCI_GETSELECTIONNCARET, ASelection, 0)
@@ -1546,13 +1546,13 @@ begin
     Result := INVALID_POSITION;
 end;
 
-procedure TDScintilla.SetSelectionNAnchor(ASelection: Integer; APosAnchor: Integer);
+procedure TDScintilla.SetSelectionNAnchor(ASelection: NativeInt; APosAnchor: NativeInt);
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     SendEditor(SCI_SETSELECTIONNANCHOR, ASelection, APosAnchor);
 end;
 
-function TDScintilla.GetSelectionNAnchor(ASelection: Integer): Integer;
+function TDScintilla.GetSelectionNAnchor(ASelection: NativeInt): NativeInt;
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     Result := SendEditor(SCI_GETSELECTIONNANCHOR, ASelection, 0)
@@ -1560,13 +1560,13 @@ begin
     Result := INVALID_POSITION;
 end;
 
-procedure TDScintilla.SetSelectionNCaretVirtualSpace(ASelection: Integer; ASpace: Integer);
+procedure TDScintilla.SetSelectionNCaretVirtualSpace(ASelection: NativeInt; ASpace: NativeInt);
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     SendEditor(SCI_SETSELECTIONNCARETVIRTUALSPACE, ASelection, ASpace);
 end;
 
-function TDScintilla.GetSelectionNCaretVirtualSpace(ASelection: Integer): Integer;
+function TDScintilla.GetSelectionNCaretVirtualSpace(ASelection: NativeInt): NativeInt;
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     Result := SendEditor(SCI_GETSELECTIONNCARETVIRTUALSPACE, ASelection, 0)
@@ -1574,13 +1574,13 @@ begin
     Result := INVALID_POSITION;
 end;
 
-procedure TDScintilla.SetSelectionNAnchorVirtualSpace(ASelection: Integer; ASpace: Integer);
+procedure TDScintilla.SetSelectionNAnchorVirtualSpace(ASelection: NativeInt; ASpace: NativeInt);
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     SendEditor(SCI_SETSELECTIONNANCHORVIRTUALSPACE, ASelection, ASpace);
 end;
 
-function TDScintilla.GetSelectionNAnchorVirtualSpace(ASelection: Integer): Integer;
+function TDScintilla.GetSelectionNAnchorVirtualSpace(ASelection: NativeInt): NativeInt;
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     Result := SendEditor(SCI_GETSELECTIONNANCHORVIRTUALSPACE, ASelection, 0)
@@ -1588,13 +1588,13 @@ begin
     Result := INVALID_POSITION;
 end;
 
-procedure TDScintilla.SetSelectionNStart(ASelection: Integer; APos: Integer);
+procedure TDScintilla.SetSelectionNStart(ASelection: NativeInt; APos: NativeInt);
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     SendEditor(SCI_SETSELECTIONNSTART, ASelection, APos);
 end;
 
-function TDScintilla.GetSelectionNStart(ASelection: Integer): Integer;
+function TDScintilla.GetSelectionNStart(ASelection: NativeInt): NativeInt;
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     Result := SendEditor(SCI_GETSELECTIONNSTART, ASelection, 0)
@@ -1602,13 +1602,13 @@ begin
     Result := INVALID_POSITION;
 end;
 
-procedure TDScintilla.SetSelectionNEnd(ASelection: Integer; APos: Integer);
+procedure TDScintilla.SetSelectionNEnd(ASelection: NativeInt; APos: NativeInt);
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     SendEditor(SCI_SETSELECTIONNEND, ASelection, APos);
 end;
 
-function TDScintilla.GetSelectionNEnd(ASelection: Integer): Integer;
+function TDScintilla.GetSelectionNEnd(ASelection: NativeInt): NativeInt;
 begin
   if (ASelection >= 0) and (ASelection < GetSelections) then
     Result := SendEditor(SCI_GETSELECTIONNEND, ASelection, 0)
@@ -1616,42 +1616,42 @@ begin
     Result := INVALID_POSITION;
 end;
 
-procedure TDScintilla.SetRectangularSelectionCaret(APos: Integer);
+procedure TDScintilla.SetRectangularSelectionCaret(APos: NativeInt);
 begin
   SendEditor(SCI_SETRECTANGULARSELECTIONCARET, APos, 0);
 end;
 
-function TDScintilla.GetRectangularSelectionCaret: Integer;
+function TDScintilla.GetRectangularSelectionCaret: NativeInt;
 begin
   Result := SendEditor(SCI_GETRECTANGULARSELECTIONCARET, 0, 0);
 end;
 
-procedure TDScintilla.SetRectangularSelectionAnchor(APosAnchor: Integer);
+procedure TDScintilla.SetRectangularSelectionAnchor(APosAnchor: NativeInt);
 begin
   SendEditor(SCI_SETRECTANGULARSELECTIONANCHOR, APosAnchor, 0);
 end;
 
-function TDScintilla.GetRectangularSelectionAnchor: Integer;
+function TDScintilla.GetRectangularSelectionAnchor: NativeInt;
 begin
   Result := SendEditor(SCI_GETRECTANGULARSELECTIONANCHOR, 0, 0);
 end;
 
-procedure TDScintilla.SetRectangularSelectionCaretVirtualSpace(ASpace: Integer);
+procedure TDScintilla.SetRectangularSelectionCaretVirtualSpace(ASpace: NativeInt);
 begin
   SendEditor(SCI_SETRECTANGULARSELECTIONCARETVIRTUALSPACE, ASpace, 0);
 end;
 
-function TDScintilla.GetRectangularSelectionCaretVirtualSpace: Integer;
+function TDScintilla.GetRectangularSelectionCaretVirtualSpace: NativeInt;
 begin
   Result := SendEditor(SCI_GETRECTANGULARSELECTIONCARETVIRTUALSPACE, 0, 0);
 end;
 
-procedure TDScintilla.SetRectangularSelectionAnchorVirtualSpace(ASpace: Integer);
+procedure TDScintilla.SetRectangularSelectionAnchorVirtualSpace(ASpace: NativeInt);
 begin
   SendEditor(SCI_SETRECTANGULARSELECTIONANCHORVIRTUALSPACE, ASpace, 0);
 end;
 
-function TDScintilla.GetRectangularSelectionAnchorVirtualSpace: Integer;
+function TDScintilla.GetRectangularSelectionAnchorVirtualSpace: NativeInt;
 begin
   Result := SendEditor(SCI_GETRECTANGULARSELECTIONANCHORVIRTUALSPACE, 0, 0);
 end;
@@ -1855,7 +1855,7 @@ end;
 //   SendEditor(SCI_SETUSEPALETTE, Integer(AUsePalette), 0);
 // end;
 
-procedure TDScintilla.AnnotationSetText(ALine: Integer);
+procedure TDScintilla.AnnotationSetText(ALine: NativeInt);
 begin
   SendEditor(SCI_ANNOTATIONSETTEXT, ALine, 0);
 end;

--- a/Sources/DScintillaPropertiesDecl.inc
+++ b/Sources/DScintillaPropertiesDecl.inc
@@ -1,17 +1,17 @@
     /// <summary>Returns the number of bytes in the document.</summary>
-    function GetLength: Integer;
+    function GetLength: NativeInt;
 
     /// <summary>Returns the character byte at the position.</summary>
-    function GetCharAt(APos: Integer): Integer;
+    function GetCharAt(APos: NativeInt): Integer;
 
     /// <summary>Returns the position of the caret.</summary>
-    function GetCurrentPos: Integer;
+    function GetCurrentPos: NativeInt;
 
     /// <summary>Returns the position of the opposite end of the selection to the caret.</summary>
-    function GetAnchor: Integer;
+    function GetAnchor: NativeInt;
 
     /// <summary>Returns the style byte at the position.</summary>
-    function GetStyleAt(APos: Integer): Integer;
+    function GetStyleAt(APos: NativeInt): Integer;
 
     /// <summary>Choose between collecting actions into the undo
     /// history and discarding them.</summary>
@@ -29,10 +29,10 @@
 
     /// <summary>Set the selection anchor to a position. The anchor is the opposite
     /// end of the selection from the caret.</summary>
-    procedure SetAnchor(APosAnchor: Integer);
+    procedure SetAnchor(APosAnchor: NativeInt);
 
     /// <summary>Retrieve the position of the last correctly styled character.</summary>
-    function GetEndStyled: Integer;
+    function GetEndStyled: NativeInt;
 
     /// <summary>Retrieve the current end of line mode - one of CRLF, CR, or LF.</summary>
     function GetEOLMode: Integer;
@@ -234,13 +234,13 @@
     function GetStyleBits: Integer;
 
     /// <summary>Used to hold extra styling information for each line.</summary>
-    procedure SetLineState(ALine: Integer; AState: Integer);
+    procedure SetLineState(ALine: NativeInt; AState: Integer);
 
     /// <summary>Retrieve the extra styling information for a line.</summary>
-    function GetLineState(ALine: Integer): Integer;
+    function GetLineState(ALine: NativeInt): Integer;
 
     /// <summary>Retrieve the last line number that has line state.</summary>
-    function GetMaxLineState: Integer;
+    function GetMaxLineState: NativeInt;
 
     /// <summary>Is the background of the line containing the caret in a different colour?</summary>
     function GetCaretLineVisible: Boolean;
@@ -337,16 +337,16 @@
     function GetUseTabs: Boolean;
 
     /// <summary>Change the indentation of a line to a number of columns.</summary>
-    procedure SetLineIndentation(ALine: Integer; AIndentSize: Integer);
+    procedure SetLineIndentation(ALine: NativeInt; AIndentSize: Integer);
 
     /// <summary>Retrieve the number of columns that a line is indented.</summary>
-    function GetLineIndentation(ALine: Integer): Integer;
+    function GetLineIndentation(ALine: NativeInt): Integer;
 
     /// <summary>Retrieve the position before the first non indentation character on a line.</summary>
-    function GetLineIndentPosition(ALine: Integer): Integer;
+    function GetLineIndentPosition(ALine: NativeInt): NativeInt;
 
     /// <summary>Retrieve the column number of a position, taking tab width into account.</summary>
-    function GetColumn(APos: Integer): Integer;
+    function GetColumn(APos: NativeInt): NativeInt;
 
     /// <summary>Show or hide the horizontal scroll bar.</summary>
     procedure SetHScrollBar(AShow: Boolean);
@@ -368,7 +368,7 @@
     function GetHighlightGuide: Integer;
 
     /// <summary>Get the position after the last visible characters on a line.</summary>
-    function GetLineEndPosition(ALine: Integer): Integer;
+    function GetLineEndPosition(ALine: NativeInt): NativeInt;
 
     /// <summary>Get the code page used to interpret the bytes of the document as characters.</summary>
     function GetCodePage: Integer;
@@ -380,19 +380,19 @@
     function GetReadOnly: Boolean;
 
     /// <summary>Sets the position of the caret.</summary>
-    procedure SetCurrentPos(APos: Integer);
+    procedure SetCurrentPos(APos: NativeInt);
 
     /// <summary>Sets the position that starts the selection - this becomes the anchor.</summary>
-    procedure SetSelectionStart(APos: Integer);
+    procedure SetSelectionStart(APos: NativeInt);
 
     /// <summary>Returns the position at the start of the selection.</summary>
-    function GetSelectionStart: Integer;
+    function GetSelectionStart: NativeInt;
 
     /// <summary>Sets the position that ends the selection - this becomes the currentPosition.</summary>
-    procedure SetSelectionEnd(APos: Integer);
+    procedure SetSelectionEnd(APos: NativeInt);
 
     /// <summary>Returns the position at the end of the selection.</summary>
-    function GetSelectionEnd: Integer;
+    function GetSelectionEnd: NativeInt;
 
     /// <summary>Sets the print magnification added to the point size of each style for printing.</summary>
     procedure SetPrintMagnification(AMagnification: Integer);
@@ -407,10 +407,10 @@
     function GetPrintColourMode: Integer;
 
     /// <summary>Retrieve the display line at the top of the display.</summary>
-    function GetFirstVisibleLine: Integer;
+    function GetFirstVisibleLine: NativeInt;
 
     /// <summary>Returns the number of lines in the document. There is always at least one.</summary>
-    function GetLineCount: Integer;
+    function GetLineCount: NativeInt;
 
     /// <summary>Sets the size in pixels of the left margin.</summary>
     procedure SetMarginLeft(APixelWidth: Integer);
@@ -431,7 +431,7 @@
     procedure SetReadOnly(AReadOnly: Boolean);
 
     /// <summary>Retrieve the number of characters in the document.</summary>
-    function GetTextLength: Integer;
+    function GetTextLength: NativeInt;
 
     /// <summary>Retrieve a pointer to a function that processes messages for this Scintilla.</summary>
     function GetDirectFunction: TDScintillaFunction;
@@ -454,17 +454,17 @@
 
     /// <summary>Sets the position that starts the target which is used for updating the
     /// document without affecting the scroll position.</summary>
-    procedure SetTargetStart(APos: Integer);
+    procedure SetTargetStart(APos: NativeInt);
 
     /// <summary>Get the position that starts the target.</summary>
-    function GetTargetStart: Integer;
+    function GetTargetStart: NativeInt;
 
     /// <summary>Sets the position that ends the target which is used for updating the
     /// document without affecting the scroll position.</summary>
-    procedure SetTargetEnd(APos: Integer);
+    procedure SetTargetEnd(APos: NativeInt);
 
     /// <summary>Get the position that ends the target.</summary>
-    function GetTargetEnd: Integer;
+    function GetTargetEnd: NativeInt;
 
     /// <summary>Set the search flags used by SearchInTarget.</summary>
     procedure SetSearchFlags(AFlags: Integer);
@@ -473,7 +473,7 @@
     function GetSearchFlags: Integer;
 
     /// <summary>Set the start position in order to change when backspacing removes the calltip.</summary>
-    procedure CallTipSetPosStart(APosStart: Integer);
+    procedure CallTipSetPosStart(APosStart: NativeInt);
 
     /// <summary>Set the background colour for the call tip.</summary>
     procedure CallTipSetBack(ABack: TColor);
@@ -493,28 +493,28 @@
     /// <summary>Set the fold level of a line.
     /// This encodes an integer level along with flags indicating whether the
     /// line is a header and whether it is effectively white space.</summary>
-    procedure SetFoldLevel(ALine: Integer; ALevel: Integer);
+    procedure SetFoldLevel(ALine: NativeInt; ALevel: Integer);
 
     /// <summary>Retrieve the fold level of a line.</summary>
-    function GetFoldLevel(ALine: Integer): Integer;
+    function GetFoldLevel(ALine: NativeInt): Integer;
 
     /// <summary>Find the last child line of a header line.</summary>
-    function GetLastChild(ALine: Integer; ALevel: Integer): Integer;
+    function GetLastChild(ALine: NativeInt; ALevel: Integer): NativeInt;
 
     /// <summary>Find the parent line of a child line.</summary>
-    function GetFoldParent(ALine: Integer): Integer;
+    function GetFoldParent(ALine: NativeInt): NativeInt;
 
     /// <summary>Is a line visible?</summary>
-    function GetLineVisible(ALine: Integer): Boolean;
+    function GetLineVisible(ALine: NativeInt): Boolean;
 
     /// <summary>Are all lines visible?</summary>
     function GetAllLinesVisible: Boolean;
 
     /// <summary>Show the children of a header line.</summary>
-    procedure SetFoldExpanded(ALine: Integer; AExpanded: Boolean);
+    procedure SetFoldExpanded(ALine: NativeInt; AExpanded: Boolean);
 
     /// <summary>Is a header line expanded?</summary>
-    function GetFoldExpanded(ALine: Integer): Boolean;
+    function GetFoldExpanded(ALine: NativeInt): Boolean;
 
     /// <summary>Set automatic folding behaviours.</summary>
     procedure SetAutomaticFold(AAutomaticFold: Integer);
@@ -617,7 +617,7 @@
     function GetFontQuality: Integer;
 
     /// <summary>Scroll so that a display line is at the top of the display.</summary>
-    procedure SetFirstVisibleLine(ALineDisplay: Integer);
+    procedure SetFirstVisibleLine(ALineDisplay: NativeInt);
 
     /// <summary>Change the effect of pasting when there are multiple selections.</summary>
     procedure SetMultiPaste(AMultiPaste: Integer);
@@ -806,10 +806,10 @@
     function GetIndicatorValue: Integer;
 
     /// <summary>Set number of entries in position cache</summary>
-    procedure SetPositionCache(ASize: Integer);
+    procedure SetPositionCache(ASize: NativeInt);
 
     /// <summary>How many entries are allocated to the position cache?</summary>
-    function GetPositionCache: Integer;
+    function GetPositionCache: NativeInt;
 
     /// <summary>Compact the document buffer and return a read-only pointer to the
     /// characters in the document.</summary>
@@ -818,7 +818,7 @@
     /// <summary>Return a read-only pointer to a range of characters in the document.
     /// May move the gap so that the range is contiguous, but will only move up
     /// to rangeLength bytes.</summary>
-    function GetRangePointer(APosition: Integer; ARangeLength: Integer): Pointer;
+    function GetRangePointer(APosition: NativeInt; ARangeLength: NativeInt): Pointer;
 
     /// <summary>Always interpret keyboard input as Unicode</summary>
     procedure SetKeysUnicode(AKeysUnicode: Boolean);
@@ -851,22 +851,22 @@
     function GetExtraDescent: Integer;
 
     /// <summary>Set the text in the text margin for a line</summary>
-    procedure MarginSetText(ALine: Integer; const AText: UnicodeString);
+    procedure MarginSetText(ALine: NativeInt; const AText: UnicodeString);
 
     /// <summary>Get the text in the text margin for a line</summary>
-    function MarginGetText(ALine: Integer): UnicodeString;
+    function MarginGetText(ALine: NativeInt): UnicodeString;
 
     /// <summary>Set the style number for the text margin for a line</summary>
-    procedure MarginSetStyle(ALine: Integer; AStyle: Integer);
+    procedure MarginSetStyle(ALine: NativeInt; AStyle: Integer);
 
     /// <summary>Get the style number for the text margin for a line</summary>
-    function MarginGetStyle(ALine: Integer): Integer;
+    function MarginGetStyle(ALine: NativeInt): Integer;
 
     /// <summary>Set the style in the text margin for a line</summary>
-    procedure MarginSetStyles(ALine: Integer; const AStyles: TDSciStyles);
+    procedure MarginSetStyles(ALine: NativeInt; const AStyles: TDSciStyles);
 
     /// <summary>Get the styles in the text margin for a line</summary>
-    function MarginGetStyles(ALine: Integer): TDSciStyles;
+    function MarginGetStyles(ALine: NativeInt): TDSciStyles;
 
     /// <summary>Get the start of the range of style numbers used for margin text</summary>
     procedure MarginSetStyleOffset(AStyle: Integer);
@@ -881,25 +881,25 @@
     function GetMarginOptions: Integer;
 
     /// <summary>Set the annotation text for a line</summary>
-    procedure AnnotationSetText(ALine: Integer; const AText: UnicodeString); overload;
+    procedure AnnotationSetText(ALine: NativeInt; const AText: UnicodeString); overload;
 
     /// <summary>Get the annotation text for a line</summary>
-    function AnnotationGetText(ALine: Integer): UnicodeString;
+    function AnnotationGetText(ALine: NativeInt): UnicodeString;
 
     /// <summary>Set the style number for the annotations for a line</summary>
-    procedure AnnotationSetStyle(ALine: Integer; AStyle: Integer);
+    procedure AnnotationSetStyle(ALine: NativeInt; AStyle: Integer);
 
     /// <summary>Get the style number for the annotations for a line</summary>
-    function AnnotationGetStyle(ALine: Integer): Integer;
+    function AnnotationGetStyle(ALine: NativeInt): Integer;
 
     /// <summary>Set the annotation styles for a line</summary>
-    procedure AnnotationSetStyles(ALine: Integer; const AStyles: TDSciStyles);
+    procedure AnnotationSetStyles(ALine: NativeInt; const AStyles: TDSciStyles);
 
     /// <summary>Get the annotation styles for a line</summary>
-    function AnnotationGetStyles(ALine: Integer): TDSciStyles;
+    function AnnotationGetStyles(ALine: NativeInt): TDSciStyles;
 
     /// <summary>Get the number of annotation lines for a line</summary>
-    function AnnotationGetLines(ALine: Integer): Integer;
+    function AnnotationGetLines(ALine: NativeInt): Integer;
 
     /// <summary>Set the visibility for the annotations for a view</summary>
     procedure AnnotationSetVisible(AVisible: Integer);
@@ -944,60 +944,60 @@
     function GetAdditionalCaretsVisible: Boolean;
 
     /// <summary>How many selections are there?</summary>
-    function GetSelections: Integer;
+    function GetSelections: NativeInt;
 
     /// <summary>Is every selected range empty?</summary>
     function GetSelectionEmpty: Boolean;
 
     /// <summary>Set the main selection</summary>
-    procedure SetMainSelection(ASelection: Integer);
+    procedure SetMainSelection(ASelection: NativeInt);
 
     /// <summary>Which selection is the main selection</summary>
-    function GetMainSelection: Integer;
+    function GetMainSelection: NativeInt;
 
-    procedure SetSelectionNCaret(ASelection: Integer; APos: Integer);
+    procedure SetSelectionNCaret(ASelection: NativeInt; APos: NativeInt);
 
-    function GetSelectionNCaret(ASelection: Integer): Integer;
+    function GetSelectionNCaret(ASelection: NativeInt): NativeInt;
 
-    procedure SetSelectionNAnchor(ASelection: Integer; APosAnchor: Integer);
+    procedure SetSelectionNAnchor(ASelection: NativeInt; APosAnchor: NativeInt);
 
-    function GetSelectionNAnchor(ASelection: Integer): Integer;
+    function GetSelectionNAnchor(ASelection: NativeInt): NativeInt;
 
-    procedure SetSelectionNCaretVirtualSpace(ASelection: Integer; ASpace: Integer);
+    procedure SetSelectionNCaretVirtualSpace(ASelection: NativeInt; ASpace: NativeInt);
 
-    function GetSelectionNCaretVirtualSpace(ASelection: Integer): Integer;
+    function GetSelectionNCaretVirtualSpace(ASelection: NativeInt): NativeInt;
 
-    procedure SetSelectionNAnchorVirtualSpace(ASelection: Integer; ASpace: Integer);
+    procedure SetSelectionNAnchorVirtualSpace(ASelection: NativeInt; ASpace: NativeInt);
 
-    function GetSelectionNAnchorVirtualSpace(ASelection: Integer): Integer;
+    function GetSelectionNAnchorVirtualSpace(ASelection: NativeInt): NativeInt;
 
     /// <summary>Sets the position that starts the selection - this becomes the anchor.</summary>
-    procedure SetSelectionNStart(ASelection: Integer; APos: Integer);
+    procedure SetSelectionNStart(ASelection: NativeInt; APos: NativeInt);
 
     /// <summary>Returns the position at the start of the selection.</summary>
-    function GetSelectionNStart(ASelection: Integer): Integer;
+    function GetSelectionNStart(ASelection: NativeInt): NativeInt;
 
     /// <summary>Sets the position that ends the selection - this becomes the currentPosition.</summary>
-    procedure SetSelectionNEnd(ASelection: Integer; APos: Integer);
+    procedure SetSelectionNEnd(ASelection: NativeInt; APos: NativeInt);
 
     /// <summary>Returns the position at the end of the selection.</summary>
-    function GetSelectionNEnd(ASelection: Integer): Integer;
+    function GetSelectionNEnd(ASelection: NativeInt): NativeInt;
 
-    procedure SetRectangularSelectionCaret(APos: Integer);
+    procedure SetRectangularSelectionCaret(APos: NativeInt);
 
-    function GetRectangularSelectionCaret: Integer;
+    function GetRectangularSelectionCaret: NativeInt;
 
-    procedure SetRectangularSelectionAnchor(APosAnchor: Integer);
+    procedure SetRectangularSelectionAnchor(APosAnchor: NativeInt);
 
-    function GetRectangularSelectionAnchor: Integer;
+    function GetRectangularSelectionAnchor: NativeInt;
 
-    procedure SetRectangularSelectionCaretVirtualSpace(ASpace: Integer);
+    procedure SetRectangularSelectionCaretVirtualSpace(ASpace: NativeInt);
 
-    function GetRectangularSelectionCaretVirtualSpace: Integer;
+    function GetRectangularSelectionCaretVirtualSpace: NativeInt;
 
-    procedure SetRectangularSelectionAnchorVirtualSpace(ASpace: Integer);
+    procedure SetRectangularSelectionAnchorVirtualSpace(ASpace: NativeInt);
 
-    function GetRectangularSelectionAnchorVirtualSpace: Integer;
+    function GetRectangularSelectionAnchorVirtualSpace: NativeInt;
 
     procedure SetVirtualSpaceOptions(AVirtualSpaceOptions: Integer);
 
@@ -1123,5 +1123,5 @@
     // procedure SetUsePalette(AUsePalette: Boolean);
 
     /// <summary>Clear the annotation text for a line</summary>
-    procedure AnnotationSetText(ALine: Integer); overload;
+    procedure AnnotationSetText(ALine: NativeInt); overload;
 

--- a/Sources/DScintillaTypes.pas
+++ b/Sources/DScintillaTypes.pas
@@ -50,6 +50,7 @@ type
 // I'm not sure about, D2010-XE, but they are 32bit only.
 {$IF CompilerVersion < 23}
   NativeInt = Integer;
+  NativeUInt = Cardinal;
 {$IFEND}
 
 {$IF CompilerVersion < 20}
@@ -62,8 +63,8 @@ type
 
 { TDSciSendEditor }
 
-  TDSciSendEditor = function(AMessage: Integer;
-    WParam: NativeInt = 0; LParam: NativeInt = 0): NativeInt of object;
+  TDSciSendEditor = function(AMessage: UINT;
+    WParam: WPARAM = 0; LParam: LPARAM = 0): LRESULT of object;
 
 { TDSciDocument }
 
@@ -87,8 +88,8 @@ type
 { TDSciCharacterRange }
 
   TDSciCharacterRange = record
-    cpMin: Integer;
-    cpMax: Integer;
+    cpMin: Long;  // Will change to be 64-bit compatible at some point according to the 3.6.0 release notes
+    cpMax: Long;  // Will change to be 64-bit compatible at some point according to the 3.6.0 release notes
   end;
 
 { TDSciTextRange }
@@ -126,7 +127,7 @@ type
   PDSciSCNotification = ^TDSciSCNotification;
   TDSciSCNotification = record
     NotifyHeader: TDSciNotifyHeader;
-    position: Integer;
+    position: NativeInt;
 	  // SCN_STYLENEEDED, SCN_DOUBLECLICK, SCN_MODIFIED, SCN_MARGINCLICK,
 	  // SCN_NEEDSHOWN, SCN_DWELLSTART, SCN_DWELLEND, SCN_CALLTIPCLICK,
 	  // SCN_HOTSPOTCLICK, SCN_HOTSPOTDOUBLECLICK, SCN_HOTSPOTRELEASECLICK,
@@ -138,23 +139,23 @@ type
 	  // SCN_KEY, SCN_DOUBLECLICK, SCN_HOTSPOTCLICK, SCN_HOTSPOTDOUBLECLICK,
 	  // SCN_HOTSPOTRELEASECLICK, SCN_INDICATORCLICK, SCN_INDICATORRELEASE,
 
-    modificationType: Integer;      // SCN_MODIFIED
-    text: PAnsiChar;                // SCN_MODIFIED
-    length: Integer;                // SCN_MODIFIED
-    linesAdded: Integer;            // SCN_MODIFIED
-    message: Integer;               // SCN_MACRORECORD
-    wParam: NativeInt;                 // SCN_MACRORECORD
-    lParam: NativeInt;                 // SCN_MACRORECORD
-    line: Integer;                  // SCN_MODIFIED
-    foldLevelNow: Integer;          // SCN_MODIFIED
-    foldLevelPrev: Integer;         // SCN_MODIFIED
-    margin: Integer;                // SCN_MARGINCLICK
-    listType: Integer;              // SCN_USERLISTSELECTION
-    x: Integer;                     // SCN_DWELLSTART, SCN_DWELLEND
-    y: Integer;                     // SCN_DWELLSTART, SCN_DWELLEND
-    token: Integer;                 // SCN_MODIFIED with SC_MOD_CONTAINER
-    annotationLinesAdded: Integer;	// SCN_MODIFIED with SC_MOD_CHANGEANNOTATION
-    updated: Integer;	              // SCN_UPDATEUI
+    modificationType: Integer;          // SCN_MODIFIED
+    text: PAnsiChar;                    // SCN_MODIFIED
+    length: NativeInt;               // SCN_MODIFIED
+    linesAdded: NativeInt;           // SCN_MODIFIED
+    message: Integer;                   // SCN_MACRORECORD
+    wParam: NativeUInt;                 // SCN_MACRORECORD
+    lParam: NativeInt;                  // SCN_MACRORECORD
+    line: NativeInt;                 // SCN_MODIFIED
+    foldLevelNow: Integer;              // SCN_MODIFIED
+    foldLevelPrev: Integer;             // SCN_MODIFIED
+    margin: Integer;                    // SCN_MARGINCLICK
+    listType: Integer;                  // SCN_USERLISTSELECTION
+    x: Integer;                         // SCN_DWELLSTART, SCN_DWELLEND
+    y: Integer;                         // SCN_DWELLSTART, SCN_DWELLEND
+    token: Integer;                     // SCN_MODIFIED with SC_MOD_CONTAINER
+    annotationLinesAdded: NativeInt; // SCN_MODIFIED with SC_MOD_CHANGEANNOTATION
+    updated: Integer;	                  // SCN_UPDATEUI
   end;
 
 { TDScintilla events - http://www.scintilla.org/ScintillaDoc.html#Notifications }
@@ -162,7 +163,7 @@ type
   TDSciNotificationEvent = procedure(ASender: TObject; const ASCN: TDSciSCNotification;
     var AHandled: Boolean) of object;
 
-  TDSciStyleNeededEvent = procedure(ASender: TObject; APosition: Integer) of object;
+  TDSciStyleNeededEvent = procedure(ASender: TObject; APosition: NativeInt) of object;
   TDSciCharAddedEvent = procedure(ASender: TObject; ACh: Integer) of object;
   TDSciSavePointReachedEvent = procedure(ASender: TObject) of object;
   TDSciSavePointLeftEvent = procedure(ASender: TObject) of object;
@@ -171,29 +172,29 @@ type
   // evt  Key=2005(Integer ch; Integer modifiers)
   // evt  DoubleClick=2006()
   TDSciUpdateUIEvent = procedure(ASender: TObject; AUpdated: Integer) of object;
-  TDSciModifiedEvent = procedure(ASender: TObject; APosition: Integer; AModificationType: Integer;
-    AText: UnicodeString; ALength: Integer; ALinesAdded: Integer; ALine: Integer;
+  TDSciModifiedEvent = procedure(ASender: TObject; APosition: NativeInt; AModificationType: Integer;
+    AText: UnicodeString; ALength: NativeInt; ALinesAdded: NativeInt; ALine: NativeInt;
     AFoldLevelNow: Integer; AFoldLevelPrev: Integer) of object;
-  TDSciModified2Event = procedure(ASender: TObject; APosition: Integer; AModificationType: Integer;
-    AText: UnicodeString; ALength: Integer; ALinesAdded: Integer; ALine: Integer;
+  TDSciModified2Event = procedure(ASender: TObject; APosition: NativeInt; AModificationType: Integer;
+    AText: UnicodeString; ALength: NativeInt; ALinesAdded: NativeInt; ALine: NativeInt;
     AFoldLevelNow: Integer; AFoldLevelPrev: Integer;
-    AToken: Integer; AAnnotationLinesAdded: Integer) of object;
-  TDSciMacroRecordEvent = procedure(ASender: TObject; AMessage: Integer; AWParam: Integer; ALParam: Integer) of object;
-  TDSciMarginClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: Integer; AMargin: Integer) of object;
-  TDSciNeedShownEvent = procedure(ASender: TObject; APosition: Integer; ALength: Integer) of object;
+    AToken: Integer; AAnnotationLinesAdded: NativeInt) of object;
+  TDSciMacroRecordEvent = procedure(ASender: TObject; AMessage: Integer; AWParam: NativeInt; ALParam: NativeUInt) of object;
+  TDSciMarginClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: NativeInt; AMargin: Integer) of object;
+  TDSciNeedShownEvent = procedure(ASender: TObject; APosition: NativeInt; ALength: NativeInt) of object;
   TDSciPaintedEvent = procedure(ASender: TObject) of object;
   TDSciUserListSelectionEvent = procedure(ASender: TObject; AListType: Integer; AText: UnicodeString) of object;
-  TDSciUserListSelection2Event = procedure(ASender: TObject; AListType: Integer; AText: UnicodeString; APosition: Integer) of object;
+  TDSciUserListSelection2Event = procedure(ASender: TObject; AListType: Integer; AText: UnicodeString; APosition: NativeInt) of object;
   TDSciDwellStartEvent = procedure(ASender: TObject; APosition, X, Y: Integer) of object;
   TDSciDwellEndEvent = procedure(ASender: TObject; APosition, X, Y: Integer) of object;
   TDSciZoomEvent = procedure(ASender: TObject) of object;
-  TDSciHotSpotClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: Integer) of object;
-  TDSciHotSpotDoubleClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: Integer) of object;
-  TDSciHotSpotReleaseClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: Integer) of object;
-  TDSciCallTipClickEvent = procedure(ASender: TObject; APosition: Integer) of object;
-  TDSciAutoCSelectionEvent = procedure(ASender: TObject; AText: UnicodeString; APosition: Integer) of object;
-  TDSciIndicatorClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: Integer) of object;
-  TDSciIndicatorReleaseEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: Integer) of object;
+  TDSciHotSpotClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: NativeInt) of object;
+  TDSciHotSpotDoubleClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: NativeInt) of object;
+  TDSciHotSpotReleaseClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: NativeInt) of object;
+  TDSciCallTipClickEvent = procedure(ASender: TObject; APosition: NativeInt) of object;
+  TDSciAutoCSelectionEvent = procedure(ASender: TObject; AText: UnicodeString; APosition: NativeInt) of object;
+  TDSciIndicatorClickEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: NativeInt) of object;
+  TDSciIndicatorReleaseEvent = procedure(ASender: TObject; AModifiers: Integer; APosition: NativeInt) of object;
   TDSciAutoCCancelledEvent = procedure(ASender: TObject) of object;
   TDSciAutoCCharDeletedEvent = procedure(ASender: TObject) of object;
 

--- a/Sources/DScintillaUtils.pas
+++ b/Sources/DScintillaUtils.pas
@@ -95,12 +95,12 @@ type
     function GetStrFromPtrA(ABuf: PAnsiChar): AnsiString;
     function GetPtrFromAStr(AStr: AnsiString): PAnsiChar;
 
-    function GetText(AMessage: Integer; AWParam: Integer; var AText: UnicodeString): Integer;
-    function GetTextA(AMessage: Integer; AWParam: Integer; var AText: AnsiString): Integer;
-    function SetText(AMessage: Integer; AWParam: Integer; const AText: UnicodeString): Integer;
-    function SetTextA(AMessage: Integer; AWParam: Integer; const AText: AnsiString): Integer;
-    function GetTextLen(AMessage: Integer; var AText: UnicodeString): Integer;
-    function SetTextLen(AMessage: Integer; const AText: UnicodeString): Integer;
+    function GetText(AMessage: Integer; AWParam: WPARAM; var AText: UnicodeString): Integer;
+    function GetTextA(AMessage: Integer; AWParam: WPARAM; var AText: AnsiString): Integer;
+    function SetText(AMessage: Integer; AWParam: WPARAM; const AText: UnicodeString): Integer;
+    function SetTextA(AMessage: Integer; AWParam: WPARAM; const AText: AnsiString): Integer;
+    function GetTextLen(AMessage: Integer; var AText: UnicodeString): NativeInt;
+    function SetTextLen(AMessage: Integer; const AText: UnicodeString): NativeInt;
 
     function SetTargetLine(ALine: Integer): Boolean;
   end;
@@ -273,57 +273,57 @@ begin
     Result:= AnsiString(ABuf);
 end;
 
-function TDSciHelper.GetText(AMessage, AWParam: Integer;
+function TDSciHelper.GetText(AMessage: Integer; AWParam: WPARAM;
   var AText: UnicodeString): Integer;
 var
   lBuf: PAnsiChar;
 begin
   lBuf := AllocMem(SendEditor(AMessage, AWParam) + 1);
   try
-    Result := SendEditor(AMessage, AWParam, NativeInt(lBuf));
+    Result := SendEditor(AMessage, AWParam, LPARAM(lBuf));
     AText := GetStrFromPtr(lBuf);
   finally
     FreeMem(lBuf);
   end;
 end;
 
-function TDSciHelper.GetTextA(AMessage, AWParam: Integer;
+function TDSciHelper.GetTextA(AMessage: Integer; AWParam: WPARAM;
   var AText: AnsiString): Integer;
 var
   lBuf: PAnsiChar;
 begin
   lBuf := AllocMem(SendEditor(AMessage, AWParam) + 1);
   try
-    Result := SendEditor(AMessage, AWParam, NativeInt(lBuf));
+    Result := SendEditor(AMessage, AWParam, LPARAM(lBuf));
     AText := GetStrFromPtrA(lBuf);
   finally
     FreeMem(lBuf);
   end;
 end;
 
-function TDSciHelper.SetText(AMessage, AWParam: Integer;
+function TDSciHelper.SetText(AMessage: Integer; AWParam: WPARAM;
   const AText: UnicodeString): Integer;
 begin
   if AText = '' then
-    Result := SendEditor(AMessage, AWParam, NativeInt(@cDSciNull))
+    Result := SendEditor(AMessage, AWParam, LPARAM(@cDSciNull))
   else
     if IsUTF8 then
-      Result := SendEditor(AMessage, AWParam, NativeInt(UnicodeStringToUTF8(AText)))
+      Result := SendEditor(AMessage, AWParam, LPARAM(UnicodeStringToUTF8(AText)))
     else
-      Result := SendEditor(AMessage, AWParam, NativeInt(AnsiString(AText)));
+      Result := SendEditor(AMessage, AWParam, LPARAM(AnsiString(AText)));
 end;
 
-function TDSciHelper.SetTextA(AMessage, AWParam: Integer;
+function TDSciHelper.SetTextA(AMessage: Integer; AWParam: WPARAM;
   const AText: AnsiString): Integer;
 begin
   if AText = '' then
-    Result := SendEditor(AMessage, AWParam, NativeInt(@cDSciNull))
+    Result := SendEditor(AMessage, AWParam, LPARAM(@cDSciNull))
   else
-    Result := SendEditor(AMessage, AWParam, NativeInt(AText));
+    Result := SendEditor(AMessage, AWParam, LPARAM(AText));
 end;
 
 function TDSciHelper.GetTextLen(AMessage: Integer;
-  var AText: UnicodeString): Integer;
+  var AText: UnicodeString): NativeInt;
 var
   lBuf: PAnsiChar;
   lLen: NativeInt;
@@ -332,7 +332,7 @@ begin
 
   lBuf := AllocMem(lLen + 1);
   try
-    Result := SendEditor(AMessage, lLen + 1, NativeInt(lBuf));
+    Result := SendEditor(AMessage, lLen + 1, LPARAM(lBuf));
     AText := GetStrFromPtr(lBuf);
   finally
     FreeMem(lBuf);
@@ -340,22 +340,22 @@ begin
 end;
 
 function TDSciHelper.SetTextLen(AMessage: Integer;
-  const AText: UnicodeString): Integer;
+  const AText: UnicodeString): NativeInt;
 var
   lUTF8: UTF8String;
   lAnsi: AnsiString;
 begin
   if AText = '' then
-    Result := SendEditor(AMessage, 0, NativeInt(@cDSciNull))
+    Result := SendEditor(AMessage, 0, LPARAM(@cDSciNull))
   else
     if IsUTF8 then
     begin
       lUTF8 := UnicodeStringToUTF8(AText);
-      Result := SendEditor(AMessage, System.Length(lUTF8), NativeInt(lUTF8));
+      Result := SendEditor(AMessage, System.Length(lUTF8), LPARAM(lUTF8));
     end else
     begin
       lAnsi := AnsiString(AText);
-      Result := SendEditor(AMessage, System.Length(lAnsi), NativeInt(lAnsi));
+      Result := SendEditor(AMessage, System.Length(lAnsi), LPARAM(lAnsi));
     end;
 end;
 


### PR DESCRIPTION
Datatypes for size, position, and other properties changed to NativeInt to support 64-bit integers in 64-bit architecture. 

**This is a breaking change for 64-bit applications using Scintilla versions older than 3.6 (August 2015).**

Fixes #24 